### PR TITLE
feat: preserve unmanaged dual-stack entries

### DIFF
--- a/internal/controller/poolsync_controller.go
+++ b/internal/controller/poolsync_controller.go
@@ -557,7 +557,7 @@ func isManagedBlock(block map[string]interface{}, managedPrefixes []netip.Prefix
 	if cidr, ok := block["cidr"].(string); ok {
 		p, err := netip.ParsePrefix(cidr)
 		if err == nil {
-			if p.Addr().Is4() {
+			if isIPv4Block(block) {
 				return false
 			}
 			return isPrefixManaged(p, managedPrefixes)
@@ -567,7 +567,7 @@ func isManagedBlock(block map[string]interface{}, managedPrefixes []netip.Prefix
 	if start, ok := block["start"].(string); ok {
 		a, err := netip.ParseAddr(start)
 		if err == nil {
-			if a.Is4() {
+			if isIPv4Block(block) {
 				return false
 			}
 			for _, mp := range managedPrefixes {
@@ -576,6 +576,20 @@ func isManagedBlock(block map[string]interface{}, managedPrefixes []netip.Prefix
 				}
 			}
 		}
+	}
+
+	return false
+}
+
+func isIPv4Block(block map[string]interface{}) bool {
+	if cidr, ok := block["cidr"].(string); ok {
+		p, err := netip.ParsePrefix(cidr)
+		return err == nil && p.Addr().Is4()
+	}
+
+	if start, ok := block["start"].(string); ok {
+		a, err := netip.ParseAddr(start)
+		return err == nil && a.Is4()
 	}
 
 	return false

--- a/internal/controller/poolsync_controller.go
+++ b/internal/controller/poolsync_controller.go
@@ -142,16 +142,18 @@ func (r *PoolSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
+	managedPrefixes := collectManagedPrefixes(&dp)
+
 	// Update the pool based on its type
 	gvk := pool.GetObjectKind().GroupVersionKind()
 	var updateErr error
 
 	switch gvk.Kind {
 	case "CiliumLoadBalancerIPPool":
-		updateErr = r.updateLoadBalancerIPPool(ctx, pool, configs)
+		updateErr = r.updateLoadBalancerIPPool(ctx, pool, configs, managedPrefixes)
 	case "CiliumCIDRGroup":
 		// CIDRGroup doesn't support start/end ranges, use CIDR only
-		updateErr = r.updateCIDRGroup(ctx, pool, configs)
+		updateErr = r.updateCIDRGroup(ctx, pool, configs, managedPrefixes)
 	default:
 		log.Info("Unknown pool type", "kind", gvk.Kind)
 		return ctrl.Result{}, nil
@@ -434,14 +436,27 @@ func (r *PoolSyncReconciler) calculateSubnetConfig(
 // updateLoadBalancerIPPool updates a CiliumLoadBalancerIPPool with the new configurations.
 // It supports both CIDR-based blocks (Mode 2) and start/end address ranges (Mode 1).
 // Multiple blocks are created for current prefix plus historical prefixes.
-func (r *PoolSyncReconciler) updateLoadBalancerIPPool(ctx context.Context, pool *unstructured.Unstructured, configs []poolConfiguration) error {
+func (r *PoolSyncReconciler) updateLoadBalancerIPPool(ctx context.Context, pool *unstructured.Unstructured, configs []poolConfiguration, managedPrefixes []netip.Prefix) error {
 	log := logf.FromContext(ctx)
+
+	existingBlocks, _, _ := unstructured.NestedSlice(pool.Object, "spec", "blocks")
+	var preservedBlocks []interface{}
+	for _, b := range existingBlocks {
+		block, ok := b.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if !isManagedBlock(block, managedPrefixes) {
+			preservedBlocks = append(preservedBlocks, block)
+		}
+	}
 
 	// CiliumLoadBalancerIPPool spec.blocks is a list of IP blocks
 	// Format can be either:
 	// - spec.blocks[].cidr for CIDR-based allocation
 	// - spec.blocks[].start + spec.blocks[].stop for address range (Cilium uses "stop" not "end")
-	blocks := make([]interface{}, 0, len(configs))
+	blocks := make([]interface{}, 0, len(preservedBlocks)+len(configs))
+	blocks = append(blocks, preservedBlocks...)
 
 	for _, config := range configs {
 		var block map[string]interface{}
@@ -461,8 +476,8 @@ func (r *PoolSyncReconciler) updateLoadBalancerIPPool(ctx context.Context, pool 
 	}
 
 	// Check if blocks actually changed before updating to avoid feedback loops
-	existingBlocks, _, _ := unstructured.NestedSlice(pool.Object, "spec", "blocks")
-	existingJSON, _ := json.Marshal(existingBlocks)
+	currentBlocks, _, _ := unstructured.NestedSlice(pool.Object, "spec", "blocks")
+	existingJSON, _ := json.Marshal(currentBlocks)
 	newJSON, _ := json.Marshal(blocks)
 	if reflect.DeepEqual(existingJSON, newJSON) {
 		log.V(2).Info("Pool blocks unchanged, skipping update", "pool", pool.GetName())
@@ -481,19 +496,37 @@ func (r *PoolSyncReconciler) updateLoadBalancerIPPool(ctx context.Context, pool 
 
 // updateCIDRGroup updates a CiliumCIDRGroup with the new CIDRs.
 // Multiple CIDRs are added for current prefix plus historical prefixes.
-func (r *PoolSyncReconciler) updateCIDRGroup(ctx context.Context, pool *unstructured.Unstructured, configs []poolConfiguration) error {
+func (r *PoolSyncReconciler) updateCIDRGroup(ctx context.Context, pool *unstructured.Unstructured, configs []poolConfiguration, managedPrefixes []netip.Prefix) error {
 	log := logf.FromContext(ctx)
 
+	existingCIDRs, _, _ := unstructured.NestedSlice(pool.Object, "spec", "externalCIDRs")
+	var preserved []interface{}
+	for _, c := range existingCIDRs {
+		cidrStr, ok := c.(string)
+		if !ok {
+			continue
+		}
+		p, err := netip.ParsePrefix(cidrStr)
+		if err != nil {
+			preserved = append(preserved, c)
+			continue
+		}
+		if !isPrefixManaged(p, managedPrefixes) {
+			preserved = append(preserved, c)
+		}
+	}
+
 	// CiliumCIDRGroup spec.externalCIDRs is a list of CIDR strings
-	externalCIDRs := make([]interface{}, 0, len(configs))
+	externalCIDRs := make([]interface{}, 0, len(preserved)+len(configs))
+	externalCIDRs = append(externalCIDRs, preserved...)
 
 	for _, config := range configs {
 		externalCIDRs = append(externalCIDRs, config.cidr)
 	}
 
 	// Check if CIDRs actually changed before updating to avoid feedback loops
-	existingCIDRs, _, _ := unstructured.NestedSlice(pool.Object, "spec", "externalCIDRs")
-	existingJSON, _ := json.Marshal(existingCIDRs)
+	currentCIDRs, _, _ := unstructured.NestedSlice(pool.Object, "spec", "externalCIDRs")
+	existingJSON, _ := json.Marshal(currentCIDRs)
 	newJSON, _ := json.Marshal(externalCIDRs)
 	if reflect.DeepEqual(existingJSON, newJSON) {
 		log.V(2).Info("CIDRGroup unchanged, skipping update", "cidrGroup", pool.GetName())
@@ -518,6 +551,58 @@ func (r *PoolSyncReconciler) setLastSyncAnnotation(pool *unstructured.Unstructur
 	}
 	annotations[AnnotationLastSync] = time.Now().UTC().Format(time.RFC3339)
 	pool.SetAnnotations(annotations)
+}
+
+func isManagedBlock(block map[string]interface{}, managedPrefixes []netip.Prefix) bool {
+	if cidr, ok := block["cidr"].(string); ok {
+		p, err := netip.ParsePrefix(cidr)
+		if err == nil {
+			if p.Addr().Is4() {
+				return false
+			}
+			return isPrefixManaged(p, managedPrefixes)
+		}
+	}
+
+	if start, ok := block["start"].(string); ok {
+		a, err := netip.ParseAddr(start)
+		if err == nil {
+			if a.Is4() {
+				return false
+			}
+			for _, mp := range managedPrefixes {
+				if mp.Contains(a) {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+func isPrefixManaged(p netip.Prefix, managedPrefixes []netip.Prefix) bool {
+	for _, mp := range managedPrefixes {
+		if mp.Contains(p.Addr()) || p.Contains(mp.Addr()) {
+			return true
+		}
+	}
+	return false
+}
+
+func collectManagedPrefixes(dp *dynamicprefixiov1alpha1.DynamicPrefix) []netip.Prefix {
+	var prefixes []netip.Prefix
+	if dp.Status.CurrentPrefix != "" {
+		if p, err := netip.ParsePrefix(dp.Status.CurrentPrefix); err == nil {
+			prefixes = append(prefixes, p)
+		}
+	}
+	for _, h := range dp.Status.History {
+		if p, err := netip.ParsePrefix(h.Prefix); err == nil {
+			prefixes = append(prefixes, p)
+		}
+	}
+	return prefixes
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/poolsync_controller_test.go
+++ b/internal/controller/poolsync_controller_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"net/netip"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -372,5 +373,83 @@ func TestGVKConstants(t *testing.T) {
 	}
 	if CiliumCIDRGroupGVK.Kind != "CiliumCIDRGroup" {
 		t.Errorf("CiliumCIDRGroupGVK.Kind = %q, want %q", CiliumCIDRGroupGVK.Kind, "CiliumCIDRGroup")
+	}
+}
+
+func TestIsManagedBlock(t *testing.T) {
+	managedPrefixes := []netip.Prefix{
+		netip.MustParsePrefix("2001:db8:1::/48"),
+		netip.MustParsePrefix("2001:db8:2::/48"),
+	}
+
+	tests := []struct {
+		name     string
+		block    map[string]interface{}
+		expected bool
+	}{
+		{name: "IPv4 CIDR never managed", block: map[string]interface{}{"cidr": "198.51.100.0/24"}, expected: false},
+		{name: "IPv6 managed CIDR", block: map[string]interface{}{"cidr": "2001:db8:1:0:f000::/80"}, expected: true},
+		{name: "IPv6 unmanaged CIDR", block: map[string]interface{}{"cidr": "fd00::/64"}, expected: false},
+		{name: "IPv6 managed range", block: map[string]interface{}{"start": "2001:db8:1::f000:0:0:0", "stop": "2001:db8:1::ffff:ffff:ffff:ffff"}, expected: true},
+		{name: "IPv6 unmanaged range", block: map[string]interface{}{"start": "fd00::1", "stop": "fd00::ff"}, expected: false},
+		{name: "IPv4 start/stop never managed", block: map[string]interface{}{"start": "10.0.0.1", "stop": "10.0.0.254"}, expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isManagedBlock(tt.block, managedPrefixes)
+			if result != tt.expected {
+				t.Errorf("isManagedBlock(%v) = %v, want %v", tt.block, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsPrefixManaged(t *testing.T) {
+	tests := []struct {
+		name     string
+		prefix   string
+		managed  []netip.Prefix
+		expected bool
+	}{
+		{name: "nil managed list", prefix: "2001:db8::/48", managed: nil, expected: false},
+		{name: "exact match", prefix: "2001:db8::/48", managed: []netip.Prefix{netip.MustParsePrefix("2001:db8::/48")}, expected: true},
+		{name: "child inside managed parent", prefix: "2001:db8:1::/64", managed: []netip.Prefix{netip.MustParsePrefix("2001:db8::/32")}, expected: true},
+		{name: "parent containing managed child", prefix: "2001:db8::/32", managed: []netip.Prefix{netip.MustParsePrefix("2001:db8:1::/48")}, expected: true},
+		{name: "disjoint", prefix: "fd00::/64", managed: []netip.Prefix{netip.MustParsePrefix("2001:db8::/32")}, expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := netip.MustParsePrefix(tt.prefix)
+			result := isPrefixManaged(p, tt.managed)
+			if result != tt.expected {
+				t.Errorf("isPrefixManaged(%s) = %v, want %v", tt.prefix, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCollectManagedPrefixes(t *testing.T) {
+	dp := &dynamicprefixiov1alpha1.DynamicPrefix{
+		Status: dynamicprefixiov1alpha1.DynamicPrefixStatus{
+			CurrentPrefix: "2001:db8:1::/48",
+			History: []dynamicprefixiov1alpha1.PrefixHistoryEntry{
+				{Prefix: "2001:db8:2::/48"},
+				{Prefix: "2001:db8:3::/48"},
+			},
+		},
+	}
+
+	prefixes := collectManagedPrefixes(dp)
+	if len(prefixes) != 3 {
+		t.Fatalf("collectManagedPrefixes returned %d prefixes, want 3", len(prefixes))
+	}
+
+	expected := []string{"2001:db8:1::/48", "2001:db8:2::/48", "2001:db8:3::/48"}
+	for i, p := range prefixes {
+		if p.String() != expected[i] {
+			t.Errorf("prefix[%d] = %q, want %q", i, p.String(), expected[i])
+		}
 	}
 }

--- a/internal/controller/poolsync_controller_test.go
+++ b/internal/controller/poolsync_controller_test.go
@@ -405,6 +405,28 @@ func TestIsManagedBlock(t *testing.T) {
 	}
 }
 
+func TestIsIPv4Block(t *testing.T) {
+	tests := []struct {
+		name     string
+		block    map[string]interface{}
+		expected bool
+	}{
+		{name: "ipv4 cidr", block: map[string]interface{}{"cidr": "198.51.100.0/24"}, expected: true},
+		{name: "ipv6 cidr", block: map[string]interface{}{"cidr": "2001:db8::/64"}, expected: false},
+		{name: "ipv4 range", block: map[string]interface{}{"start": "10.0.0.1", "stop": "10.0.0.254"}, expected: true},
+		{name: "ipv6 range", block: map[string]interface{}{"start": "2001:db8::1", "stop": "2001:db8::ff"}, expected: false},
+		{name: "malformed", block: map[string]interface{}{"cidr": "not-a-cidr"}, expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isIPv4Block(tt.block); got != tt.expected {
+				t.Errorf("isIPv4Block(%v) = %v, want %v", tt.block, got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestIsPrefixManaged(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -451,5 +473,46 @@ func TestCollectManagedPrefixes(t *testing.T) {
 		if p.String() != expected[i] {
 			t.Errorf("prefix[%d] = %q, want %q", i, p.String(), expected[i])
 		}
+	}
+}
+
+func TestIsManagedBlock_MalformedInput(t *testing.T) {
+	managedPrefixes := []netip.Prefix{netip.MustParsePrefix("2001:db8::/32")}
+	tests := []struct {
+		name     string
+		block    map[string]interface{}
+		expected bool
+	}{
+		{name: "empty block", block: map[string]interface{}{}, expected: false},
+		{name: "malformed cidr", block: map[string]interface{}{"cidr": "garbage"}, expected: false},
+		{name: "malformed start", block: map[string]interface{}{"start": "garbage", "stop": "2001:db8::1"}, expected: false},
+		{name: "non-string cidr", block: map[string]interface{}{"cidr": 42}, expected: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isManagedBlock(tt.block, managedPrefixes); got != tt.expected {
+				t.Errorf("isManagedBlock(%v) = %v, want %v", tt.block, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsPrefixManaged_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name     string
+		prefix   string
+		managed  []netip.Prefix
+		expected bool
+	}{
+		{name: "ipv4 disjoint", prefix: "198.51.100.0/24", managed: []netip.Prefix{netip.MustParsePrefix("2001:db8::/32")}, expected: false},
+		{name: "single host inside managed", prefix: "2001:db8::1/128", managed: []netip.Prefix{netip.MustParsePrefix("2001:db8::/32")}, expected: true},
+		{name: "managed host inside parent", prefix: "2001:db8::/32", managed: []netip.Prefix{netip.MustParsePrefix("2001:db8::1/128")}, expected: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isPrefixManaged(netip.MustParsePrefix(tt.prefix), tt.managed); got != tt.expected {
+				t.Errorf("isPrefixManaged(%s) = %v, want %v", tt.prefix, got, tt.expected)
+			}
+		})
 	}
 }

--- a/internal/controller/servicesync_controller.go
+++ b/internal/controller/servicesync_controller.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -92,6 +93,10 @@ func (r *ServiceSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// Fetch the referenced DynamicPrefix
 	var dp dynamicprefixiov1alpha1.DynamicPrefix
 	if err := r.Get(ctx, types.NamespacedName{Name: dpName}, &dp); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.V(1).Info("Referenced DynamicPrefix not found, will retry", "name", dpName)
+			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+		}
 		log.Error(err, "Failed to get DynamicPrefix", "name", dpName)
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}

--- a/internal/controller/servicesync_controller.go
+++ b/internal/controller/servicesync_controller.go
@@ -119,6 +119,13 @@ func (r *ServiceSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
+	// Preserve non-managed IPs and targets (IPv4, hostnames, static IPv6 outside managed prefixes)
+	managedPrefixes := r.collectManagedPrefixes(&dp)
+
+	existingIPs := annotations[AnnotationCiliumIPs]
+	preservedIPs := extractUnmanagedIPs(existingIPs, managedPrefixes)
+	finalIPs := append(preservedIPs, allIPs...)
+
 	// Update Service annotations
 	updated := false
 	newAnnotations := make(map[string]string)
@@ -126,16 +133,20 @@ func (r *ServiceSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		newAnnotations[k] = v
 	}
 
-	// Set lbipam.cilium.io/ips with all IPs
-	allIPsStr := strings.Join(allIPs, ",")
-	if annotations[AnnotationCiliumIPs] != allIPsStr {
-		newAnnotations[AnnotationCiliumIPs] = allIPsStr
+	// Set lbipam.cilium.io/ips with preserved entries plus all managed IPs
+	finalIPsStr := strings.Join(finalIPs, ",")
+	if annotations[AnnotationCiliumIPs] != finalIPsStr {
+		newAnnotations[AnnotationCiliumIPs] = finalIPsStr
 		updated = true
 	}
 
-	// Set external-dns target to current IP only
-	if annotations[AnnotationExternalDNSTarget] != currentIP {
-		newAnnotations[AnnotationExternalDNSTarget] = currentIP
+	// Set external-dns target to preserved entries plus current managed IP only
+	existingTarget := annotations[AnnotationExternalDNSTarget]
+	preservedTargets := extractUnmanagedIPs(existingTarget, managedPrefixes)
+	finalTargets := append(preservedTargets, currentIP)
+	finalTargetStr := strings.Join(finalTargets, ",")
+	if annotations[AnnotationExternalDNSTarget] != finalTargetStr {
+		newAnnotations[AnnotationExternalDNSTarget] = finalTargetStr
 		updated = true
 	}
 
@@ -148,10 +159,57 @@ func (r *ServiceSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			log.Error(err, "Failed to update Service annotations")
 			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 		}
-		log.Info("Service annotations updated", "service", req.NamespacedName, "allIPs", allIPsStr, "dnsTarget", currentIP)
+		log.Info("Service annotations updated", "service", req.NamespacedName, "allIPs", finalIPsStr, "dnsTarget", finalTargetStr)
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// collectManagedPrefixes returns all current and historical prefixes managed by the operator.
+func (r *ServiceSyncReconciler) collectManagedPrefixes(dp *dynamicprefixiov1alpha1.DynamicPrefix) []netip.Prefix {
+	return collectManagedPrefixes(dp)
+}
+
+// extractUnmanagedIPs parses a comma-separated list and returns only the entries not managed
+// by the operator. IPv4 addresses, hostnames, and IPv6 addresses outside the managed prefixes
+// are preserved; IPv6 addresses inside managed prefixes are filtered out.
+func extractUnmanagedIPs(ipsAnnotation string, managedPrefixes []netip.Prefix) []string {
+	if ipsAnnotation == "" {
+		return nil
+	}
+
+	var preserved []string
+	for _, raw := range strings.Split(ipsAnnotation, ",") {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+
+		addr, err := netip.ParseAddr(raw)
+		if err != nil {
+			preserved = append(preserved, raw)
+			continue
+		}
+
+		if addr.Is4() || addr.Is4In6() {
+			preserved = append(preserved, raw)
+			continue
+		}
+
+		managed := false
+		for _, p := range managedPrefixes {
+			if p.Contains(addr) {
+				managed = true
+				break
+			}
+		}
+
+		if !managed {
+			preserved = append(preserved, raw)
+		}
+	}
+
+	return preserved
 }
 
 // getCurrentServiceIP returns the current IPv6 IP from Service status.

--- a/internal/controller/servicesync_controller_test.go
+++ b/internal/controller/servicesync_controller_test.go
@@ -179,6 +179,48 @@ var _ = Describe("ServiceSync Controller", func() {
 			// Should have last-sync annotation
 			Expect(annotations).To(HaveKey(AnnotationLastSync))
 		})
+
+		It("should preserve IPv4 addresses in dual-stack annotation", func() {
+			svc := &corev1.Service{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: serviceNS}, svc)).To(Succeed())
+
+			annotations := svc.GetAnnotations()
+			annotations[AnnotationCiliumIPs] = "198.51.100.10," + currentIP
+			svc.SetAnnotations(annotations)
+			Expect(k8sClient.Update(ctx, svc)).To(Succeed())
+
+			reconciler := &ServiceSyncReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: serviceName, Namespace: serviceNS}})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: serviceNS}, svc)).To(Succeed())
+			ipsAnnotation := svc.GetAnnotations()[AnnotationCiliumIPs]
+
+			Expect(ipsAnnotation).To(HavePrefix("198.51.100.10,"))
+			Expect(ipsAnnotation).To(ContainSubstring(currentIP))
+			Expect(ipsAnnotation).To(ContainSubstring(historicalIP))
+		})
+
+		It("should preserve hostname in external-dns target annotation", func() {
+			svc := &corev1.Service{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: serviceNS}, svc)).To(Succeed())
+
+			annotations := svc.GetAnnotations()
+			annotations[AnnotationCiliumIPs] = "198.51.100.10," + currentIP
+			annotations[AnnotationExternalDNSTarget] = "example.com," + currentIP
+			svc.SetAnnotations(annotations)
+			Expect(k8sClient.Update(ctx, svc)).To(Succeed())
+
+			reconciler := &ServiceSyncReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: serviceName, Namespace: serviceNS}})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: serviceNS}, svc)).To(Succeed())
+			dnsTarget := svc.GetAnnotations()[AnnotationExternalDNSTarget]
+
+			Expect(dnsTarget).To(HavePrefix("example.com,"))
+			Expect(dnsTarget).To(ContainSubstring(currentIP))
+		})
 	})
 
 	Context("When reconciling a Service in simple mode", func() {
@@ -363,6 +405,74 @@ func TestServiceSyncReconciler_applyIPOffset(t *testing.T) {
 			result := r.applyIPOffset(base, tt.offset)
 			if result != expected {
 				t.Errorf("applyIPOffset() = %v, want %v", result, expected)
+			}
+		})
+	}
+}
+
+func TestExtractUnmanagedIPs(t *testing.T) {
+	managedPrefixes := []netip.Prefix{
+		netip.MustParsePrefix("2001:db8:1::/48"),
+		netip.MustParsePrefix("2001:db8:2::/48"),
+	}
+
+	tests := []struct {
+		name     string
+		input    string
+		prefixes []netip.Prefix
+		expected []string
+	}{
+		{name: "empty string", input: "", prefixes: managedPrefixes, expected: nil},
+		{name: "managed IPv6 only", input: "2001:db8:1::1,2001:db8:2::2", prefixes: managedPrefixes, expected: nil},
+		{name: "IPv4 only", input: "192.168.1.1,10.0.0.1", prefixes: managedPrefixes, expected: []string{"192.168.1.1", "10.0.0.1"}},
+		{name: "dual-stack", input: "198.51.100.10,2001:db8:1::ffff:0:2", prefixes: managedPrefixes, expected: []string{"198.51.100.10"}},
+		{name: "static IPv6 outside managed prefix", input: "fd00::1,2001:db8:1::1", prefixes: managedPrefixes, expected: []string{"fd00::1"}},
+		{name: "mixed values", input: "198.51.100.10,fd00::1,2001:db8:1::ffff:0:2,2001:db8:2::ffff:0:2", prefixes: managedPrefixes, expected: []string{"198.51.100.10", "fd00::1"}},
+		{name: "no managed prefixes", input: "192.168.1.1,2001:db8:1::1,fd00::1", prefixes: nil, expected: []string{"192.168.1.1", "2001:db8:1::1", "fd00::1"}},
+		{name: "hostname preserved", input: "example.com,2001:db8:1::1", prefixes: managedPrefixes, expected: []string{"example.com"}},
+		{name: "spaces around entries", input: " 198.51.100.10 , 2001:db8:1::1 ", prefixes: managedPrefixes, expected: []string{"198.51.100.10"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractUnmanagedIPs(tt.input, tt.prefixes)
+			if len(result) != len(tt.expected) {
+				t.Fatalf("extractUnmanagedIPs(%q) returned %d items, want %d: %v", tt.input, len(result), len(tt.expected), result)
+			}
+			for i, v := range result {
+				if v != tt.expected[i] {
+					t.Errorf("extractUnmanagedIPs(%q)[%d] = %q, want %q", tt.input, i, v, tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestExtractUnmanagedIPs_MalformedInput(t *testing.T) {
+	managed := []netip.Prefix{netip.MustParsePrefix("2001:db8::/32")}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{name: "multiple commas", input: ",,,", expected: nil},
+		{name: "garbage entry preserved", input: "not-an-ip", expected: []string{"not-an-ip"}},
+		{name: "garbage mixed with valid IPs", input: "192.168.1.1,garbage,2001:db8::1", expected: []string{"192.168.1.1", "garbage"}},
+		{name: "CIDR notation preserved as-is", input: "10.0.0.0/24,2001:db8::1", expected: []string{"10.0.0.0/24"}},
+		{name: "IP with port preserved", input: "192.168.1.1:8080", expected: []string{"192.168.1.1:8080"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractUnmanagedIPs(tt.input, managed)
+			if len(result) != len(tt.expected) {
+				t.Fatalf("got %d items %v, want %d items %v", len(result), result, len(tt.expected), tt.expected)
+			}
+			for i, v := range result {
+				if v != tt.expected[i] {
+					t.Errorf("[%d] = %q, want %q", i, v, tt.expected[i])
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- preserve IPv4, hostnames, and static IPv6 entries in Service HA annotations while rotating managed IPv6 addresses
- keep unmanaged pool blocks and CIDRGroup entries instead of overwriting them during prefix sync
- add focused tests for Service annotation preservation and managed-prefix filtering helpers

## Testing
- ran focused ServiceSync and PoolSync controller tests

Closes #4