### PR TITLE
feat: add static suffix annotation for services

### DIFF
--- a/internal/controller/poolsync_controller.go
+++ b/internal/controller/poolsync_controller.go
@@ -142,16 +142,18 @@ func (r *PoolSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
+	managedPrefixes := collectManagedPrefixes(&dp)
+
 	// Update the pool based on its type
 	gvk := pool.GetObjectKind().GroupVersionKind()
 	var updateErr error
 
 	switch gvk.Kind {
 	case "CiliumLoadBalancerIPPool":
-		updateErr = r.updateLoadBalancerIPPool(ctx, pool, configs)
+		updateErr = r.updateLoadBalancerIPPool(ctx, pool, configs, managedPrefixes)
 	case "CiliumCIDRGroup":
 		// CIDRGroup doesn't support start/end ranges, use CIDR only
-		updateErr = r.updateCIDRGroup(ctx, pool, configs)
+		updateErr = r.updateCIDRGroup(ctx, pool, configs, managedPrefixes)
 	default:
 		log.Info("Unknown pool type", "kind", gvk.Kind)
 		return ctrl.Result{}, nil
@@ -434,14 +436,27 @@ func (r *PoolSyncReconciler) calculateSubnetConfig(
 // updateLoadBalancerIPPool updates a CiliumLoadBalancerIPPool with the new configurations.
 // It supports both CIDR-based blocks (Mode 2) and start/end address ranges (Mode 1).
 // Multiple blocks are created for current prefix plus historical prefixes.
-func (r *PoolSyncReconciler) updateLoadBalancerIPPool(ctx context.Context, pool *unstructured.Unstructured, configs []poolConfiguration) error {
+func (r *PoolSyncReconciler) updateLoadBalancerIPPool(ctx context.Context, pool *unstructured.Unstructured, configs []poolConfiguration, managedPrefixes []netip.Prefix) error {
 	log := logf.FromContext(ctx)
+
+	existingBlocks, _, _ := unstructured.NestedSlice(pool.Object, "spec", "blocks")
+	var preservedBlocks []interface{}
+	for _, b := range existingBlocks {
+		block, ok := b.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if !isManagedBlock(block, managedPrefixes) {
+			preservedBlocks = append(preservedBlocks, block)
+		}
+	}
 
 	// CiliumLoadBalancerIPPool spec.blocks is a list of IP blocks
 	// Format can be either:
 	// - spec.blocks[].cidr for CIDR-based allocation
 	// - spec.blocks[].start + spec.blocks[].stop for address range (Cilium uses "stop" not "end")
-	blocks := make([]interface{}, 0, len(configs))
+	blocks := make([]interface{}, 0, len(preservedBlocks)+len(configs))
+	blocks = append(blocks, preservedBlocks...)
 
 	for _, config := range configs {
 		var block map[string]interface{}
@@ -461,8 +476,8 @@ func (r *PoolSyncReconciler) updateLoadBalancerIPPool(ctx context.Context, pool 
 	}
 
 	// Check if blocks actually changed before updating to avoid feedback loops
-	existingBlocks, _, _ := unstructured.NestedSlice(pool.Object, "spec", "blocks")
-	existingJSON, _ := json.Marshal(existingBlocks)
+	currentBlocks, _, _ := unstructured.NestedSlice(pool.Object, "spec", "blocks")
+	existingJSON, _ := json.Marshal(currentBlocks)
 	newJSON, _ := json.Marshal(blocks)
 	if reflect.DeepEqual(existingJSON, newJSON) {
 		log.V(2).Info("Pool blocks unchanged, skipping update", "pool", pool.GetName())
@@ -481,19 +496,37 @@ func (r *PoolSyncReconciler) updateLoadBalancerIPPool(ctx context.Context, pool 
 
 // updateCIDRGroup updates a CiliumCIDRGroup with the new CIDRs.
 // Multiple CIDRs are added for current prefix plus historical prefixes.
-func (r *PoolSyncReconciler) updateCIDRGroup(ctx context.Context, pool *unstructured.Unstructured, configs []poolConfiguration) error {
+func (r *PoolSyncReconciler) updateCIDRGroup(ctx context.Context, pool *unstructured.Unstructured, configs []poolConfiguration, managedPrefixes []netip.Prefix) error {
 	log := logf.FromContext(ctx)
 
+	existingCIDRs, _, _ := unstructured.NestedSlice(pool.Object, "spec", "externalCIDRs")
+	var preserved []interface{}
+	for _, c := range existingCIDRs {
+		cidrStr, ok := c.(string)
+		if !ok {
+			continue
+		}
+		p, err := netip.ParsePrefix(cidrStr)
+		if err != nil {
+			preserved = append(preserved, c)
+			continue
+		}
+		if !isPrefixManaged(p, managedPrefixes) {
+			preserved = append(preserved, c)
+		}
+	}
+
 	// CiliumCIDRGroup spec.externalCIDRs is a list of CIDR strings
-	externalCIDRs := make([]interface{}, 0, len(configs))
+	externalCIDRs := make([]interface{}, 0, len(preserved)+len(configs))
+	externalCIDRs = append(externalCIDRs, preserved...)
 
 	for _, config := range configs {
 		externalCIDRs = append(externalCIDRs, config.cidr)
 	}
 
 	// Check if CIDRs actually changed before updating to avoid feedback loops
-	existingCIDRs, _, _ := unstructured.NestedSlice(pool.Object, "spec", "externalCIDRs")
-	existingJSON, _ := json.Marshal(existingCIDRs)
+	currentCIDRs, _, _ := unstructured.NestedSlice(pool.Object, "spec", "externalCIDRs")
+	existingJSON, _ := json.Marshal(currentCIDRs)
 	newJSON, _ := json.Marshal(externalCIDRs)
 	if reflect.DeepEqual(existingJSON, newJSON) {
 		log.V(2).Info("CIDRGroup unchanged, skipping update", "cidrGroup", pool.GetName())
@@ -518,6 +551,58 @@ func (r *PoolSyncReconciler) setLastSyncAnnotation(pool *unstructured.Unstructur
 	}
 	annotations[AnnotationLastSync] = time.Now().UTC().Format(time.RFC3339)
 	pool.SetAnnotations(annotations)
+}
+
+func isManagedBlock(block map[string]interface{}, managedPrefixes []netip.Prefix) bool {
+	if cidr, ok := block["cidr"].(string); ok {
+		p, err := netip.ParsePrefix(cidr)
+		if err == nil {
+			if p.Addr().Is4() {
+				return false
+			}
+			return isPrefixManaged(p, managedPrefixes)
+		}
+	}
+
+	if start, ok := block["start"].(string); ok {
+		a, err := netip.ParseAddr(start)
+		if err == nil {
+			if a.Is4() {
+				return false
+			}
+			for _, mp := range managedPrefixes {
+				if mp.Contains(a) {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+func isPrefixManaged(p netip.Prefix, managedPrefixes []netip.Prefix) bool {
+	for _, mp := range managedPrefixes {
+		if mp.Contains(p.Addr()) || p.Contains(mp.Addr()) {
+			return true
+		}
+	}
+	return false
+}
+
+func collectManagedPrefixes(dp *dynamicprefixiov1alpha1.DynamicPrefix) []netip.Prefix {
+	var prefixes []netip.Prefix
+	if dp.Status.CurrentPrefix != "" {
+		if p, err := netip.ParsePrefix(dp.Status.CurrentPrefix); err == nil {
+			prefixes = append(prefixes, p)
+		}
+	}
+	for _, h := range dp.Status.History {
+		if p, err := netip.ParsePrefix(h.Prefix); err == nil {
+			prefixes = append(prefixes, p)
+		}
+	}
+	return prefixes
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/poolsync_controller_test.go
+++ b/internal/controller/poolsync_controller_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"net/netip"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -372,5 +373,83 @@ func TestGVKConstants(t *testing.T) {
 	}
 	if CiliumCIDRGroupGVK.Kind != "CiliumCIDRGroup" {
 		t.Errorf("CiliumCIDRGroupGVK.Kind = %q, want %q", CiliumCIDRGroupGVK.Kind, "CiliumCIDRGroup")
+	}
+}
+
+func TestIsManagedBlock(t *testing.T) {
+	managedPrefixes := []netip.Prefix{
+		netip.MustParsePrefix("2001:db8:1::/48"),
+		netip.MustParsePrefix("2001:db8:2::/48"),
+	}
+
+	tests := []struct {
+		name     string
+		block    map[string]interface{}
+		expected bool
+	}{
+		{name: "IPv4 CIDR never managed", block: map[string]interface{}{"cidr": "198.51.100.0/24"}, expected: false},
+		{name: "IPv6 managed CIDR", block: map[string]interface{}{"cidr": "2001:db8:1:0:f000::/80"}, expected: true},
+		{name: "IPv6 unmanaged CIDR", block: map[string]interface{}{"cidr": "fd00::/64"}, expected: false},
+		{name: "IPv6 managed range", block: map[string]interface{}{"start": "2001:db8:1::f000:0:0:0", "stop": "2001:db8:1::ffff:ffff:ffff:ffff"}, expected: true},
+		{name: "IPv6 unmanaged range", block: map[string]interface{}{"start": "fd00::1", "stop": "fd00::ff"}, expected: false},
+		{name: "IPv4 start/stop never managed", block: map[string]interface{}{"start": "10.0.0.1", "stop": "10.0.0.254"}, expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isManagedBlock(tt.block, managedPrefixes)
+			if result != tt.expected {
+				t.Errorf("isManagedBlock(%v) = %v, want %v", tt.block, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsPrefixManaged(t *testing.T) {
+	tests := []struct {
+		name     string
+		prefix   string
+		managed  []netip.Prefix
+		expected bool
+	}{
+		{name: "nil managed list", prefix: "2001:db8::/48", managed: nil, expected: false},
+		{name: "exact match", prefix: "2001:db8::/48", managed: []netip.Prefix{netip.MustParsePrefix("2001:db8::/48")}, expected: true},
+		{name: "child inside managed parent", prefix: "2001:db8:1::/64", managed: []netip.Prefix{netip.MustParsePrefix("2001:db8::/32")}, expected: true},
+		{name: "parent containing managed child", prefix: "2001:db8::/32", managed: []netip.Prefix{netip.MustParsePrefix("2001:db8:1::/48")}, expected: true},
+		{name: "disjoint", prefix: "fd00::/64", managed: []netip.Prefix{netip.MustParsePrefix("2001:db8::/32")}, expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := netip.MustParsePrefix(tt.prefix)
+			result := isPrefixManaged(p, tt.managed)
+			if result != tt.expected {
+				t.Errorf("isPrefixManaged(%s) = %v, want %v", tt.prefix, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCollectManagedPrefixes(t *testing.T) {
+	dp := &dynamicprefixiov1alpha1.DynamicPrefix{
+		Status: dynamicprefixiov1alpha1.DynamicPrefixStatus{
+			CurrentPrefix: "2001:db8:1::/48",
+			History: []dynamicprefixiov1alpha1.PrefixHistoryEntry{
+				{Prefix: "2001:db8:2::/48"},
+				{Prefix: "2001:db8:3::/48"},
+			},
+		},
+	}
+
+	prefixes := collectManagedPrefixes(dp)
+	if len(prefixes) != 3 {
+		t.Fatalf("collectManagedPrefixes returned %d prefixes, want 3", len(prefixes))
+	}
+
+	expected := []string{"2001:db8:1::/48", "2001:db8:2::/48", "2001:db8:3::/48"}
+	for i, p := range prefixes {
+		if p.String() != expected[i] {
+			t.Errorf("prefix[%d] = %q, want %q", i, p.String(), expected[i])
+		}
 	}
 }

--- a/internal/controller/servicesync_controller.go
+++ b/internal/controller/servicesync_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"net/netip"
 	"strings"
 	"time"
@@ -51,6 +52,11 @@ const (
 	// AnnotationServiceSubnet specifies which subnet to use for Service IPs.
 	// This is used when the DynamicPrefix uses subnets (Mode 2).
 	AnnotationServiceSubnet = "dynamic-prefix.io/service-subnet"
+
+	// AnnotationServiceSuffix specifies a static IPv6 suffix to combine with the
+	// current and historical prefixes. This allows Services to keep a stable host
+	// portion across prefix changes without requiring a subnet or address range.
+	AnnotationServiceSuffix = "dynamic-prefix.io/service-suffix"
 )
 
 // ServiceSyncReconciler reconciles LoadBalancer Services for HA mode prefix transitions.
@@ -258,6 +264,7 @@ func (r *ServiceSyncReconciler) calculateServiceIPs(
 
 	addressRangeName := annotations[AnnotationServiceAddressRange]
 	subnetName := annotations[AnnotationServiceSubnet]
+	suffix := annotations[AnnotationServiceSuffix]
 	// Also check the pool-level annotations for backward compatibility
 	if addressRangeName == "" {
 		addressRangeName = annotations[AnnotationAddressRange]
@@ -269,7 +276,13 @@ func (r *ServiceSyncReconciler) calculateServiceIPs(
 	var allIPs []string
 	var currentPrefixIP string
 
-	if addressRangeName != "" {
+	if suffix != "" {
+		currentPrefixIP, allIPs, err = r.calculateSuffixIPs(dp, suffix, maxHistory)
+		if err != nil {
+			log.Error(err, "Failed to calculate suffix IPs", "suffix", suffix)
+			return []string{currentServiceIP}, currentServiceIP, nil
+		}
+	} else if addressRangeName != "" {
 		// Mode 1: Address ranges
 		currentPrefixIP, allIPs, err = r.calculateAddressRangeIPs(dp, currentAddr, addressRangeName, maxHistory)
 		if err != nil {
@@ -291,6 +304,79 @@ func (r *ServiceSyncReconciler) calculateServiceIPs(
 	}
 
 	return allIPs, currentPrefixIP, nil
+}
+
+// calculateSuffixIPs combines the current and historical prefixes with a static suffix.
+func (r *ServiceSyncReconciler) calculateSuffixIPs(
+	dp *dynamicprefixiov1alpha1.DynamicPrefix,
+	suffix string,
+	maxHistory int,
+) (string, []string, error) {
+	currentPrefix, err := netip.ParsePrefix(dp.Status.CurrentPrefix)
+	if err != nil {
+		return "", nil, err
+	}
+
+	currentIP, err := combinePrefixSuffix(currentPrefix, suffix)
+	if err != nil {
+		return "", nil, err
+	}
+
+	allIPs := []string{currentIP.String()}
+	for i, histEntry := range dp.Status.History {
+		if i >= maxHistory {
+			break
+		}
+
+		histPrefix, err := netip.ParsePrefix(histEntry.Prefix)
+		if err != nil {
+			continue
+		}
+
+		histIP, err := combinePrefixSuffix(histPrefix, suffix)
+		if err != nil {
+			continue
+		}
+
+		allIPs = append(allIPs, histIP.String())
+	}
+
+	return currentIP.String(), allIPs, nil
+}
+
+// combinePrefixSuffix replaces the host portion of a prefix with the provided suffix.
+func combinePrefixSuffix(basePrefix netip.Prefix, suffix string) (netip.Addr, error) {
+	suffixAddr, err := netip.ParseAddr(suffix)
+	if err != nil {
+		return netip.Addr{}, err
+	}
+	if !suffixAddr.Is6() {
+		return netip.Addr{}, fmt.Errorf("suffix %q is not a valid IPv6 address", suffix)
+	}
+
+	base := basePrefix.Masked().Addr().As16()
+	suffixBytes := suffixAddr.As16()
+	prefixBits := basePrefix.Bits()
+
+	if prefixBits >= 128 {
+		return basePrefix.Addr(), nil
+	}
+
+	fullBytes := prefixBits / 8
+	remainingBits := prefixBits % 8
+
+	result := base
+	if remainingBits != 0 {
+		mask := byte(0xFF << (8 - remainingBits))
+		result[fullBytes] = (base[fullBytes] & mask) | (suffixBytes[fullBytes] &^ mask)
+		fullBytes++
+	}
+
+	for i := fullBytes; i < len(result); i++ {
+		result[i] = suffixBytes[i]
+	}
+
+	return netip.AddrFrom16(result), nil
 }
 
 // calculateAddressRangeIPs calculates IPs for address range mode.

--- a/internal/controller/servicesync_controller.go
+++ b/internal/controller/servicesync_controller.go
@@ -119,6 +119,13 @@ func (r *ServiceSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
+	// Preserve non-managed IPs and targets (IPv4, hostnames, static IPv6 outside managed prefixes)
+	managedPrefixes := r.collectManagedPrefixes(&dp)
+
+	existingIPs := annotations[AnnotationCiliumIPs]
+	preservedIPs := extractUnmanagedIPs(existingIPs, managedPrefixes)
+	finalIPs := append(preservedIPs, allIPs...)
+
 	// Update Service annotations
 	updated := false
 	newAnnotations := make(map[string]string)
@@ -126,16 +133,20 @@ func (r *ServiceSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		newAnnotations[k] = v
 	}
 
-	// Set lbipam.cilium.io/ips with all IPs
-	allIPsStr := strings.Join(allIPs, ",")
-	if annotations[AnnotationCiliumIPs] != allIPsStr {
-		newAnnotations[AnnotationCiliumIPs] = allIPsStr
+	// Set lbipam.cilium.io/ips with preserved entries plus all managed IPs
+	finalIPsStr := strings.Join(finalIPs, ",")
+	if annotations[AnnotationCiliumIPs] != finalIPsStr {
+		newAnnotations[AnnotationCiliumIPs] = finalIPsStr
 		updated = true
 	}
 
-	// Set external-dns target to current IP only
-	if annotations[AnnotationExternalDNSTarget] != currentIP {
-		newAnnotations[AnnotationExternalDNSTarget] = currentIP
+	// Set external-dns target to preserved entries plus current managed IP only
+	existingTarget := annotations[AnnotationExternalDNSTarget]
+	preservedTargets := extractUnmanagedIPs(existingTarget, managedPrefixes)
+	finalTargets := append(preservedTargets, currentIP)
+	finalTargetStr := strings.Join(finalTargets, ",")
+	if annotations[AnnotationExternalDNSTarget] != finalTargetStr {
+		newAnnotations[AnnotationExternalDNSTarget] = finalTargetStr
 		updated = true
 	}
 
@@ -148,10 +159,57 @@ func (r *ServiceSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			log.Error(err, "Failed to update Service annotations")
 			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 		}
-		log.Info("Service annotations updated", "service", req.NamespacedName, "allIPs", allIPsStr, "dnsTarget", currentIP)
+		log.Info("Service annotations updated", "service", req.NamespacedName, "allIPs", finalIPsStr, "dnsTarget", finalTargetStr)
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// collectManagedPrefixes returns all current and historical prefixes managed by the operator.
+func (r *ServiceSyncReconciler) collectManagedPrefixes(dp *dynamicprefixiov1alpha1.DynamicPrefix) []netip.Prefix {
+	return collectManagedPrefixes(dp)
+}
+
+// extractUnmanagedIPs parses a comma-separated list and returns only the entries not managed
+// by the operator. IPv4 addresses, hostnames, and IPv6 addresses outside the managed prefixes
+// are preserved; IPv6 addresses inside managed prefixes are filtered out.
+func extractUnmanagedIPs(ipsAnnotation string, managedPrefixes []netip.Prefix) []string {
+	if ipsAnnotation == "" {
+		return nil
+	}
+
+	var preserved []string
+	for _, raw := range strings.Split(ipsAnnotation, ",") {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+
+		addr, err := netip.ParseAddr(raw)
+		if err != nil {
+			preserved = append(preserved, raw)
+			continue
+		}
+
+		if addr.Is4() || addr.Is4In6() {
+			preserved = append(preserved, raw)
+			continue
+		}
+
+		managed := false
+		for _, p := range managedPrefixes {
+			if p.Contains(addr) {
+				managed = true
+				break
+			}
+		}
+
+		if !managed {
+			preserved = append(preserved, raw)
+		}
+	}
+
+	return preserved
 }
 
 // getCurrentServiceIP returns the current IPv6 IP from Service status.

--- a/internal/controller/servicesync_controller.go
+++ b/internal/controller/servicesync_controller.go
@@ -53,10 +53,11 @@ const (
 	// This is used when the DynamicPrefix uses subnets (Mode 2).
 	AnnotationServiceSubnet = "dynamic-prefix.io/service-subnet"
 
-	// AnnotationServiceSuffix specifies a static IPv6 suffix to combine with the
-	// current and historical prefixes. This allows Services to keep a stable host
-	// portion across prefix changes without requiring a subnet or address range.
-	AnnotationServiceSuffix = "dynamic-prefix.io/service-suffix"
+	// AnnotationSuffix specifies a static IPv6 suffix (host part) for a Service.
+	// When set, the operator calculates full IPv6 addresses by combining the current
+	// (and historical) prefix with this suffix, instead of inferring it from the
+	// Service's currently assigned IP.
+	AnnotationSuffix = "dynamic-prefix.io/suffix"
 )
 
 // ServiceSyncReconciler reconciles LoadBalancer Services for HA mode prefix transitions.
@@ -110,19 +111,29 @@ func (r *ServiceSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	log.Info("Syncing Service for HA mode", "service", req.NamespacedName, "dynamicPrefix", dpName)
 
-	// Get current assigned IP from Service status
-	currentServiceIP := r.getCurrentServiceIP(&svc)
-	if currentServiceIP == "" {
-		// Service doesn't have an IP yet, let Cilium assign one
-		log.V(1).Info("Service has no IP assigned yet, skipping")
-		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-	}
+	var allIPs []string
+	var currentIP string
+	var err error
 
-	// Calculate all IPs (current + historical) based on the Service's current IP
-	allIPs, currentIP, err := r.calculateServiceIPs(ctx, &dp, &svc, currentServiceIP)
-	if err != nil {
-		log.Error(err, "Failed to calculate Service IPs")
-		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+	if suffix, ok := annotations[AnnotationSuffix]; ok && suffix != "" {
+		allIPs, currentIP, err = r.calculateSuffixIPs(&dp, suffix)
+		if err != nil {
+			log.Error(err, "Failed to calculate IPs from suffix", "suffix", suffix)
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		}
+		log.V(1).Info("Using suffix-based IP calculation", "suffix", suffix, "currentIP", currentIP)
+	} else {
+		currentServiceIP := r.getCurrentServiceIP(&svc)
+		if currentServiceIP == "" {
+			log.V(1).Info("Service has no IP assigned yet, skipping")
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		}
+
+		allIPs, currentIP, err = r.calculateServiceIPs(ctx, &dp, &svc, currentServiceIP)
+		if err != nil {
+			log.Error(err, "Failed to calculate Service IPs")
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		}
 	}
 
 	// Preserve non-managed IPs and targets (IPv4, hostnames, static IPv6 outside managed prefixes)
@@ -264,7 +275,6 @@ func (r *ServiceSyncReconciler) calculateServiceIPs(
 
 	addressRangeName := annotations[AnnotationServiceAddressRange]
 	subnetName := annotations[AnnotationServiceSubnet]
-	suffix := annotations[AnnotationServiceSuffix]
 	// Also check the pool-level annotations for backward compatibility
 	if addressRangeName == "" {
 		addressRangeName = annotations[AnnotationAddressRange]
@@ -276,13 +286,7 @@ func (r *ServiceSyncReconciler) calculateServiceIPs(
 	var allIPs []string
 	var currentPrefixIP string
 
-	if suffix != "" {
-		currentPrefixIP, allIPs, err = r.calculateSuffixIPs(dp, suffix, maxHistory)
-		if err != nil {
-			log.Error(err, "Failed to calculate suffix IPs", "suffix", suffix)
-			return []string{currentServiceIP}, currentServiceIP, nil
-		}
-	} else if addressRangeName != "" {
+	if addressRangeName != "" {
 		// Mode 1: Address ranges
 		currentPrefixIP, allIPs, err = r.calculateAddressRangeIPs(dp, currentAddr, addressRangeName, maxHistory)
 		if err != nil {
@@ -306,21 +310,29 @@ func (r *ServiceSyncReconciler) calculateServiceIPs(
 	return allIPs, currentPrefixIP, nil
 }
 
-// calculateSuffixIPs combines the current and historical prefixes with a static suffix.
+// calculateSuffixIPs calculates IPv6 addresses by combining a static suffix with
+// the current and historical prefixes. Returns (allIPs, currentIP, error).
 func (r *ServiceSyncReconciler) calculateSuffixIPs(
 	dp *dynamicprefixiov1alpha1.DynamicPrefix,
 	suffix string,
-	maxHistory int,
-) (string, []string, error) {
+) ([]string, string, error) {
+	suffixAddr, err := netip.ParseAddr(suffix)
+	if err != nil {
+		return nil, "", fmt.Errorf("invalid IPv6 suffix %q: %w", suffix, err)
+	}
+	suffixBytes := suffixAddr.As16()
+
 	currentPrefix, err := netip.ParsePrefix(dp.Status.CurrentPrefix)
 	if err != nil {
-		return "", nil, err
+		return nil, "", err
 	}
 
-	currentIP, err := combinePrefixSuffix(currentPrefix, suffix)
-	if err != nil {
-		return "", nil, err
+	maxHistory := 2
+	if dp.Spec.Transition != nil && dp.Spec.Transition.MaxPrefixHistory > 0 {
+		maxHistory = dp.Spec.Transition.MaxPrefixHistory
 	}
+
+	currentIP := combinePrefixSuffix(currentPrefix, suffixBytes)
 
 	allIPs := []string{currentIP.String()}
 	for i, histEntry := range dp.Status.History {
@@ -333,50 +345,34 @@ func (r *ServiceSyncReconciler) calculateSuffixIPs(
 			continue
 		}
 
-		histIP, err := combinePrefixSuffix(histPrefix, suffix)
-		if err != nil {
-			continue
-		}
+		histIP := combinePrefixSuffix(histPrefix, suffixBytes)
 
 		allIPs = append(allIPs, histIP.String())
 	}
 
-	return currentIP.String(), allIPs, nil
+	return allIPs, currentIP.String(), nil
 }
 
-// combinePrefixSuffix replaces the host portion of a prefix with the provided suffix.
-func combinePrefixSuffix(basePrefix netip.Prefix, suffix string) (netip.Addr, error) {
-	suffixAddr, err := netip.ParseAddr(suffix)
-	if err != nil {
-		return netip.Addr{}, err
-	}
-	if !suffixAddr.Is6() {
-		return netip.Addr{}, fmt.Errorf("suffix %q is not a valid IPv6 address", suffix)
-	}
 
-	base := basePrefix.Masked().Addr().As16()
-	suffixBytes := suffixAddr.As16()
-	prefixBits := basePrefix.Bits()
+// combinePrefixSuffix combines a prefix's network part with a suffix's host part.
+func combinePrefixSuffix(pfx netip.Prefix, suffixBytes [16]byte) netip.Addr {
+	prefixBytes := pfx.Addr().As16()
+	prefixLen := pfx.Bits()
 
-	if prefixBits >= 128 {
-		return basePrefix.Addr(), nil
-	}
-
-	fullBytes := prefixBits / 8
-	remainingBits := prefixBits % 8
-
-	result := base
-	if remainingBits != 0 {
-		mask := byte(0xFF << (8 - remainingBits))
-		result[fullBytes] = (base[fullBytes] & mask) | (suffixBytes[fullBytes] &^ mask)
-		fullBytes++
+	var result [16]byte
+	for i := 0; i < 16; i++ {
+		bitPos := i * 8
+		if bitPos+8 <= prefixLen {
+			result[i] = prefixBytes[i]
+		} else if bitPos >= prefixLen {
+			result[i] = suffixBytes[i]
+		} else {
+			mask := byte(0xFF << (8 - (prefixLen - bitPos)))
+			result[i] = (prefixBytes[i] & mask) | (suffixBytes[i] & ^mask)
+		}
 	}
 
-	for i := fullBytes; i < len(result); i++ {
-		result[i] = suffixBytes[i]
-	}
-
-	return netip.AddrFrom16(result), nil
+	return netip.AddrFrom16(result)
 }
 
 // calculateAddressRangeIPs calculates IPs for address range mode.

--- a/internal/controller/servicesync_controller_test.go
+++ b/internal/controller/servicesync_controller_test.go
@@ -221,6 +221,27 @@ var _ = Describe("ServiceSync Controller", func() {
 			Expect(dnsTarget).To(HavePrefix("example.com,"))
 			Expect(dnsTarget).To(ContainSubstring(currentIP))
 		})
+
+		It("should use a static suffix annotation across prefix history", func() {
+			svc := &corev1.Service{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: serviceNS}, svc)).To(Succeed())
+
+			annotations := svc.GetAnnotations()
+			delete(annotations, AnnotationServiceAddressRange)
+			annotations[AnnotationServiceSuffix] = "::beef:42"
+			svc.SetAnnotations(annotations)
+			Expect(k8sClient.Update(ctx, svc)).To(Succeed())
+
+			reconciler := &ServiceSyncReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: serviceName, Namespace: serviceNS}})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: serviceNS}, svc)).To(Succeed())
+			ipsAnnotation := svc.GetAnnotations()[AnnotationCiliumIPs]
+
+			Expect(ipsAnnotation).To(ContainSubstring("2001:db8:1::beef:42"))
+			Expect(ipsAnnotation).To(ContainSubstring("2001:db8:2::beef:42"))
+		})
 	})
 
 	Context("When reconciling a Service in simple mode", func() {
@@ -410,6 +431,40 @@ func TestServiceSyncReconciler_applyIPOffset(t *testing.T) {
 	}
 }
 
+func TestCombinePrefixSuffix(t *testing.T) {
+	tests := []struct {
+		name     string
+		prefix   string
+		suffix   string
+		expected string
+		wantErr  bool
+	}{
+		{name: "simple /48", prefix: "2001:db8:1::/48", suffix: "::beef:42", expected: "2001:db8:1::beef:42"},
+		{name: "keep network nibble on /64", prefix: "2001:db8:1:abcd::/64", suffix: "::f00d", expected: "2001:db8:1:abcd::f00d"},
+		{name: "non-byte-aligned /65", prefix: "2001:db8::/65", suffix: "::1", expected: "2001:db8::1"},
+		{name: "invalid suffix", prefix: "2001:db8::/48", suffix: "not-an-ip", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prefix := netip.MustParsePrefix(tt.prefix)
+			result, err := combinePrefixSuffix(prefix, tt.suffix)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for suffix %q", tt.suffix)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.String() != tt.expected {
+				t.Errorf("combinePrefixSuffix(%s, %s) = %s, want %s", tt.prefix, tt.suffix, result.String(), tt.expected)
+			}
+		})
+	}
+}
+
 func TestExtractUnmanagedIPs(t *testing.T) {
 	managedPrefixes := []netip.Prefix{
 		netip.MustParsePrefix("2001:db8:1::/48"),
@@ -503,6 +558,11 @@ func TestServiceSyncAnnotationConstants(t *testing.T) {
 			name:     "AnnotationServiceSubnet",
 			constant: AnnotationServiceSubnet,
 			expected: "dynamic-prefix.io/service-subnet",
+		},
+		{
+			name:     "AnnotationServiceSuffix",
+			constant: AnnotationServiceSuffix,
+			expected: "dynamic-prefix.io/service-suffix",
 		},
 	}
 

--- a/internal/controller/servicesync_controller_test.go
+++ b/internal/controller/servicesync_controller_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"net/netip"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -228,7 +229,7 @@ var _ = Describe("ServiceSync Controller", func() {
 
 			annotations := svc.GetAnnotations()
 			delete(annotations, AnnotationServiceAddressRange)
-			annotations[AnnotationServiceSuffix] = "::beef:42"
+			annotations[AnnotationSuffix] = "::beef:42"
 			svc.SetAnnotations(annotations)
 			Expect(k8sClient.Update(ctx, svc)).To(Succeed())
 
@@ -437,29 +438,275 @@ func TestCombinePrefixSuffix(t *testing.T) {
 		prefix   string
 		suffix   string
 		expected string
-		wantErr  bool
 	}{
-		{name: "simple /48", prefix: "2001:db8:1::/48", suffix: "::beef:42", expected: "2001:db8:1::beef:42"},
-		{name: "keep network nibble on /64", prefix: "2001:db8:1:abcd::/64", suffix: "::f00d", expected: "2001:db8:1:abcd::f00d"},
-		{name: "non-byte-aligned /65", prefix: "2001:db8::/65", suffix: "::1", expected: "2001:db8::1"},
-		{name: "invalid suffix", prefix: "2001:db8::/48", suffix: "not-an-ip", wantErr: true},
+		{name: "/48 prefix with host suffix", prefix: "2001:db8:1::/48", suffix: "::ffff:0:2", expected: "2001:db8:1::ffff:0:2"},
+		{name: "/56 prefix with host suffix", prefix: "2001:db8:abcd:100::/56", suffix: "::ffff:0:2", expected: "2001:db8:abcd:100::ffff:0:2"},
+		{name: "/56 prefix with different suffix", prefix: "2001:db8:abcd:100::/56", suffix: "::ffff:0:10", expected: "2001:db8:abcd:100::ffff:0:10"},
+		{name: "/64 prefix with suffix", prefix: "2001:db8:1:2::/64", suffix: "::1", expected: "2001:db8:1:2::1"},
+		{name: "/48 prefix preserves high bits only from prefix", prefix: "2001:db8:abcd::/48", suffix: "::1234:5678:9abc:def0", expected: "2001:db8:abcd:0:1234:5678:9abc:def0"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			prefix := netip.MustParsePrefix(tt.prefix)
-			result, err := combinePrefixSuffix(prefix, tt.suffix)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("expected error for suffix %q", tt.suffix)
-				}
-				return
+			result := combinePrefixSuffix(prefix, netip.MustParseAddr(tt.suffix).As16())
+			if result.String() != tt.expected {
+				t.Errorf("combinePrefixSuffix(%s, %s) = %s, want %s", tt.prefix, tt.suffix, result.String(), tt.expected)
 			}
+		})
+	}
+}
+
+func TestCalculateSuffixIPs(t *testing.T) {
+	r := &ServiceSyncReconciler{}
+	dp := &dynamicprefixiov1alpha1.DynamicPrefix{
+		Spec: dynamicprefixiov1alpha1.DynamicPrefixSpec{
+			Transition: &dynamicprefixiov1alpha1.TransitionSpec{Mode: dynamicprefixiov1alpha1.TransitionModeHA, MaxPrefixHistory: 2},
+		},
+		Status: dynamicprefixiov1alpha1.DynamicPrefixStatus{
+			CurrentPrefix: "2001:db8:abcd:100::/56",
+			History:       []dynamicprefixiov1alpha1.PrefixHistoryEntry{{Prefix: "2001:db8:abcd:200::/56"}},
+		},
+	}
+
+	allIPs, currentIP, err := r.calculateSuffixIPs(dp, "::ffff:0:2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if currentIP != netip.MustParseAddr("2001:db8:abcd:100:0:ffff:0:2").String() {
+		t.Errorf("currentIP = %q", currentIP)
+	}
+	if len(allIPs) != 2 {
+		t.Fatalf("allIPs has %d entries, want 2", len(allIPs))
+	}
+}
+
+func TestCalculateSuffixIPs_NoPrefix(t *testing.T) {
+	r := &ServiceSyncReconciler{}
+	_, _, err := r.calculateSuffixIPs(&dynamicprefixiov1alpha1.DynamicPrefix{}, "::ffff:0:2")
+	if err == nil {
+		t.Error("expected error for empty current prefix, got nil")
+	}
+}
+
+func TestCalculateSuffixIPs_InvalidSuffix(t *testing.T) {
+	r := &ServiceSyncReconciler{}
+	dp := &dynamicprefixiov1alpha1.DynamicPrefix{Status: dynamicprefixiov1alpha1.DynamicPrefixStatus{CurrentPrefix: "2001:db8::/48"}}
+	_, _, err := r.calculateSuffixIPs(dp, "not-an-ip")
+	if err == nil {
+		t.Error("expected error for invalid suffix, got nil")
+	}
+}
+
+func TestCalculateSuffixIPs_MultipleHistory(t *testing.T) {
+	r := &ServiceSyncReconciler{}
+	dp := &dynamicprefixiov1alpha1.DynamicPrefix{
+		Spec: dynamicprefixiov1alpha1.DynamicPrefixSpec{Transition: &dynamicprefixiov1alpha1.TransitionSpec{Mode: dynamicprefixiov1alpha1.TransitionModeHA, MaxPrefixHistory: 3}},
+		Status: dynamicprefixiov1alpha1.DynamicPrefixStatus{
+			CurrentPrefix: "2001:db8:abcd:100::/56",
+			History: []dynamicprefixiov1alpha1.PrefixHistoryEntry{{Prefix: "2001:db8:abcd:200::/56"}, {Prefix: "2001:db8:abcd:300::/56"}, {Prefix: "2001:db8:abcd:400::/56"}},
+		},
+	}
+	allIPs, _, err := r.calculateSuffixIPs(dp, "::1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(allIPs) != 4 {
+		t.Fatalf("allIPs has %d entries, want 4", len(allIPs))
+	}
+}
+
+func TestCalculateSuffixIPs_MaxHistoryLimit(t *testing.T) {
+	r := &ServiceSyncReconciler{}
+	dp := &dynamicprefixiov1alpha1.DynamicPrefix{
+		Spec: dynamicprefixiov1alpha1.DynamicPrefixSpec{Transition: &dynamicprefixiov1alpha1.TransitionSpec{Mode: dynamicprefixiov1alpha1.TransitionModeHA, MaxPrefixHistory: 1}},
+		Status: dynamicprefixiov1alpha1.DynamicPrefixStatus{CurrentPrefix: "2001:db8:1::/48", History: []dynamicprefixiov1alpha1.PrefixHistoryEntry{{Prefix: "2001:db8:2::/48"}, {Prefix: "2001:db8:3::/48"}}},
+	}
+	allIPs, _, err := r.calculateSuffixIPs(dp, "::42")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(allIPs) != 2 {
+		t.Fatalf("allIPs has %d entries, want 2", len(allIPs))
+	}
+}
+
+func TestCalculateSuffixIPs_DifferentPrefixLengths(t *testing.T) {
+	r := &ServiceSyncReconciler{}
+	tests := []struct{ name, prefix, suffix, expected string }{
+		{name: "/48 prefix", prefix: "2001:db8:abcd::/48", suffix: "::f000:0:0:1", expected: netip.MustParseAddr("2001:db8:abcd:0:f000:0:0:1").String()},
+		{name: "/56 prefix", prefix: "2001:db8:abcd:100::/56", suffix: "::f000:0:0:1", expected: netip.MustParseAddr("2001:db8:abcd:100:f000:0:0:1").String()},
+		{name: "/64 prefix", prefix: "2001:db8:1:2::/64", suffix: "::dead:beef", expected: netip.MustParseAddr("2001:db8:1:2::dead:beef").String()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dp := &dynamicprefixiov1alpha1.DynamicPrefix{Status: dynamicprefixiov1alpha1.DynamicPrefixStatus{CurrentPrefix: tt.prefix}}
+			_, currentIP, err := r.calculateSuffixIPs(dp, tt.suffix)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if result.String() != tt.expected {
-				t.Errorf("combinePrefixSuffix(%s, %s) = %s, want %s", tt.prefix, tt.suffix, result.String(), tt.expected)
+			if currentIP != tt.expected {
+				t.Errorf("currentIP = %q, want %q", currentIP, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSuffixAnnotation_EndToEnd(t *testing.T) {
+	tests := []struct {
+		name              string
+		annotations       map[string]string
+		existingCiliumIPs string
+		existingDNSTarget string
+		dpCurrentPrefix   string
+		dpHistory         []string
+		maxHistory        int
+		expectCiliumIPs   func(*testing.T, string)
+		expectDNSTarget   func(*testing.T, string)
+	}{
+		{
+			name:              "suffix with IPv4-only cilium annotation",
+			annotations:       map[string]string{AnnotationName: "my-dp", AnnotationSuffix: "::ffff:0:2"},
+			existingCiliumIPs: "198.51.100.10",
+			dpCurrentPrefix:   "2001:db8:abcd:100::/56",
+			dpHistory:         []string{"2001:db8:abcd:200::/56"},
+			maxHistory:        2,
+			expectCiliumIPs: func(t *testing.T, ips string) {
+				t.Helper()
+				if !strings.HasPrefix(ips, "198.51.100.10,") {
+					t.Errorf("expected IPv4 first, got: %s", ips)
+				}
+			},
+			expectDNSTarget: func(t *testing.T, target string) {
+				t.Helper()
+				if !strings.Contains(target, netip.MustParseAddr("2001:db8:abcd:100:0:ffff:0:2").String()) {
+					t.Errorf("unexpected target: %s", target)
+				}
+			},
+		},
+		{
+			name:              "dual-stack hostname target preserved",
+			annotations:       map[string]string{AnnotationName: "my-dp", AnnotationSuffix: "::ffff:0:2"},
+			existingCiliumIPs: "198.51.100.10",
+			existingDNSTarget: "example.com",
+			dpCurrentPrefix:   "2001:db8:abcd:100::/56",
+			dpHistory:         []string{"2001:db8:abcd:200::/56"},
+			maxHistory:        2,
+			expectDNSTarget: func(t *testing.T, target string) {
+				t.Helper()
+				if !strings.HasPrefix(target, "example.com,") {
+					t.Errorf("expected hostname first, got: %s", target)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dp := &dynamicprefixiov1alpha1.DynamicPrefix{
+				Spec: dynamicprefixiov1alpha1.DynamicPrefixSpec{Transition: &dynamicprefixiov1alpha1.TransitionSpec{Mode: dynamicprefixiov1alpha1.TransitionModeHA, MaxPrefixHistory: tt.maxHistory}},
+				Status: dynamicprefixiov1alpha1.DynamicPrefixStatus{CurrentPrefix: tt.dpCurrentPrefix},
+			}
+			for _, h := range tt.dpHistory {
+				dp.Status.History = append(dp.Status.History, dynamicprefixiov1alpha1.PrefixHistoryEntry{Prefix: h})
+			}
+			r := &ServiceSyncReconciler{}
+			allIPs, currentIP, err := r.calculateSuffixIPs(dp, tt.annotations[AnnotationSuffix])
+			if err != nil {
+				t.Fatalf("calculateSuffixIPs failed: %v", err)
+			}
+			managedPrefixes := collectManagedPrefixes(dp)
+			finalIPsStr := strings.Join(append(extractUnmanagedIPs(tt.existingCiliumIPs, managedPrefixes), allIPs...), ",")
+			finalTargetStr := strings.Join(append(extractUnmanagedIPs(tt.existingDNSTarget, managedPrefixes), currentIP), ",")
+			if tt.expectCiliumIPs != nil {
+				tt.expectCiliumIPs(t, finalIPsStr)
+			}
+			if tt.expectDNSTarget != nil {
+				tt.expectDNSTarget(t, finalTargetStr)
+			}
+		})
+	}
+}
+
+func TestSuffixAnnotation_RequiresName(t *testing.T) {
+	if AnnotationName != "dynamic-prefix.io/name" {
+		t.Fatalf("AnnotationName = %q", AnnotationName)
+	}
+	if AnnotationSuffix != "dynamic-prefix.io/suffix" {
+		t.Fatalf("AnnotationSuffix = %q", AnnotationSuffix)
+	}
+}
+
+func TestCalculateSuffixIPs_InvalidInputs(t *testing.T) {
+	r := &ServiceSyncReconciler{}
+	validDP := &dynamicprefixiov1alpha1.DynamicPrefix{Status: dynamicprefixiov1alpha1.DynamicPrefixStatus{CurrentPrefix: "2001:db8::/48"}}
+	tests := []struct {
+		name      string
+		dp        *dynamicprefixiov1alpha1.DynamicPrefix
+		suffix    string
+		expectErr bool
+	}{
+		{name: "empty suffix", dp: validDP, suffix: "", expectErr: true},
+		{name: "whitespace suffix", dp: validDP, suffix: "   ", expectErr: true},
+		{name: "CIDR suffix", dp: validDP, suffix: "::1/128", expectErr: true},
+		{name: "garbage suffix", dp: validDP, suffix: "hello-world", expectErr: true},
+		{name: "bad current prefix", dp: &dynamicprefixiov1alpha1.DynamicPrefix{Status: dynamicprefixiov1alpha1.DynamicPrefixStatus{CurrentPrefix: "not-a-prefix"}}, suffix: "::1", expectErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := r.calculateSuffixIPs(tt.dp, tt.suffix)
+			if tt.expectErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestCalculateSuffixIPs_MalformedHistorySkipped(t *testing.T) {
+	r := &ServiceSyncReconciler{}
+	dp := &dynamicprefixiov1alpha1.DynamicPrefix{
+		Spec: dynamicprefixiov1alpha1.DynamicPrefixSpec{Transition: &dynamicprefixiov1alpha1.TransitionSpec{Mode: dynamicprefixiov1alpha1.TransitionModeHA, MaxPrefixHistory: 5}},
+		Status: dynamicprefixiov1alpha1.DynamicPrefixStatus{CurrentPrefix: "2001:db8::/48", History: []dynamicprefixiov1alpha1.PrefixHistoryEntry{{Prefix: "2001:db8:1::/48"}, {Prefix: "garbage"}, {Prefix: ""}, {Prefix: "2001:db8::1"}, {Prefix: "2001:db8:2::/48"}}},
+	}
+	allIPs, _, err := r.calculateSuffixIPs(dp, "::42")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(allIPs) != 3 {
+		t.Errorf("allIPs has %d entries, want 3", len(allIPs))
+	}
+}
+
+func TestCombinePrefixSuffix_EdgeCases(t *testing.T) {
+	tests := []struct{ name, prefix, suffix, expected string }{
+		{name: "/128 prefix ignores suffix", prefix: "2001:db8::1/128", suffix: "::ffff", expected: "2001:db8::1"},
+		{name: "zero suffix keeps network address", prefix: "2001:db8:abcd::/48", suffix: "::", expected: "2001:db8:abcd::"},
+		{name: "all ones suffix", prefix: "2001:db8::/32", suffix: "::ffff:ffff:ffff:ffff:ffff:ffff", expected: "2001:db8:ffff:ffff:ffff:ffff:ffff:ffff"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := combinePrefixSuffix(netip.MustParsePrefix(tt.prefix), netip.MustParseAddr(tt.suffix).As16())
+			if result != netip.MustParseAddr(tt.expected) {
+				t.Errorf("got %s want %s", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCollectManagedPrefixes_InvalidEntries(t *testing.T) {
+	tests := []struct {
+		name          string
+		dp            *dynamicprefixiov1alpha1.DynamicPrefix
+		expectedCount int
+	}{
+		{name: "all valid", dp: &dynamicprefixiov1alpha1.DynamicPrefix{Status: dynamicprefixiov1alpha1.DynamicPrefixStatus{CurrentPrefix: "2001:db8::/48", History: []dynamicprefixiov1alpha1.PrefixHistoryEntry{{Prefix: "2001:db8:1::/48"}}}}, expectedCount: 2},
+		{name: "garbage current prefix", dp: &dynamicprefixiov1alpha1.DynamicPrefix{Status: dynamicprefixiov1alpha1.DynamicPrefixStatus{CurrentPrefix: "garbage", History: []dynamicprefixiov1alpha1.PrefixHistoryEntry{{Prefix: "2001:db8:1::/48"}}}}, expectedCount: 1},
+		{name: "completely empty status", dp: &dynamicprefixiov1alpha1.DynamicPrefix{}, expectedCount: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := len(collectManagedPrefixes(tt.dp)); got != tt.expectedCount {
+				t.Errorf("got %d prefixes, want %d", got, tt.expectedCount)
 			}
 		})
 	}
@@ -560,9 +807,9 @@ func TestServiceSyncAnnotationConstants(t *testing.T) {
 			expected: "dynamic-prefix.io/service-subnet",
 		},
 		{
-			name:     "AnnotationServiceSuffix",
-			constant: AnnotationServiceSuffix,
-			expected: "dynamic-prefix.io/service-suffix",
+			name:     "AnnotationSuffix",
+			constant: AnnotationSuffix,
+			expected: "dynamic-prefix.io/suffix",
 		},
 	}
 

--- a/internal/controller/servicesync_controller_test.go
+++ b/internal/controller/servicesync_controller_test.go
@@ -179,6 +179,48 @@ var _ = Describe("ServiceSync Controller", func() {
 			// Should have last-sync annotation
 			Expect(annotations).To(HaveKey(AnnotationLastSync))
 		})
+
+		It("should preserve IPv4 addresses in dual-stack annotation", func() {
+			svc := &corev1.Service{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: serviceNS}, svc)).To(Succeed())
+
+			annotations := svc.GetAnnotations()
+			annotations[AnnotationCiliumIPs] = "198.51.100.10," + currentIP
+			svc.SetAnnotations(annotations)
+			Expect(k8sClient.Update(ctx, svc)).To(Succeed())
+
+			reconciler := &ServiceSyncReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: serviceName, Namespace: serviceNS}})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: serviceNS}, svc)).To(Succeed())
+			ipsAnnotation := svc.GetAnnotations()[AnnotationCiliumIPs]
+
+			Expect(ipsAnnotation).To(HavePrefix("198.51.100.10,"))
+			Expect(ipsAnnotation).To(ContainSubstring(currentIP))
+			Expect(ipsAnnotation).To(ContainSubstring(historicalIP))
+		})
+
+		It("should preserve hostname in external-dns target annotation", func() {
+			svc := &corev1.Service{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: serviceNS}, svc)).To(Succeed())
+
+			annotations := svc.GetAnnotations()
+			annotations[AnnotationCiliumIPs] = "198.51.100.10," + currentIP
+			annotations[AnnotationExternalDNSTarget] = "example.com," + currentIP
+			svc.SetAnnotations(annotations)
+			Expect(k8sClient.Update(ctx, svc)).To(Succeed())
+
+			reconciler := &ServiceSyncReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: serviceName, Namespace: serviceNS}})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: serviceNS}, svc)).To(Succeed())
+			dnsTarget := svc.GetAnnotations()[AnnotationExternalDNSTarget]
+
+			Expect(dnsTarget).To(HavePrefix("example.com,"))
+			Expect(dnsTarget).To(ContainSubstring(currentIP))
+		})
 	})
 
 	Context("When reconciling a Service in simple mode", func() {
@@ -363,6 +405,74 @@ func TestServiceSyncReconciler_applyIPOffset(t *testing.T) {
 			result := r.applyIPOffset(base, tt.offset)
 			if result != expected {
 				t.Errorf("applyIPOffset() = %v, want %v", result, expected)
+			}
+		})
+	}
+}
+
+func TestExtractUnmanagedIPs(t *testing.T) {
+	managedPrefixes := []netip.Prefix{
+		netip.MustParsePrefix("2001:db8:1::/48"),
+		netip.MustParsePrefix("2001:db8:2::/48"),
+	}
+
+	tests := []struct {
+		name     string
+		input    string
+		prefixes []netip.Prefix
+		expected []string
+	}{
+		{name: "empty string", input: "", prefixes: managedPrefixes, expected: nil},
+		{name: "managed IPv6 only", input: "2001:db8:1::1,2001:db8:2::2", prefixes: managedPrefixes, expected: nil},
+		{name: "IPv4 only", input: "192.168.1.1,10.0.0.1", prefixes: managedPrefixes, expected: []string{"192.168.1.1", "10.0.0.1"}},
+		{name: "dual-stack", input: "198.51.100.10,2001:db8:1::ffff:0:2", prefixes: managedPrefixes, expected: []string{"198.51.100.10"}},
+		{name: "static IPv6 outside managed prefix", input: "fd00::1,2001:db8:1::1", prefixes: managedPrefixes, expected: []string{"fd00::1"}},
+		{name: "mixed values", input: "198.51.100.10,fd00::1,2001:db8:1::ffff:0:2,2001:db8:2::ffff:0:2", prefixes: managedPrefixes, expected: []string{"198.51.100.10", "fd00::1"}},
+		{name: "no managed prefixes", input: "192.168.1.1,2001:db8:1::1,fd00::1", prefixes: nil, expected: []string{"192.168.1.1", "2001:db8:1::1", "fd00::1"}},
+		{name: "hostname preserved", input: "example.com,2001:db8:1::1", prefixes: managedPrefixes, expected: []string{"example.com"}},
+		{name: "spaces around entries", input: " 198.51.100.10 , 2001:db8:1::1 ", prefixes: managedPrefixes, expected: []string{"198.51.100.10"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractUnmanagedIPs(tt.input, tt.prefixes)
+			if len(result) != len(tt.expected) {
+				t.Fatalf("extractUnmanagedIPs(%q) returned %d items, want %d: %v", tt.input, len(result), len(tt.expected), result)
+			}
+			for i, v := range result {
+				if v != tt.expected[i] {
+					t.Errorf("extractUnmanagedIPs(%q)[%d] = %q, want %q", tt.input, i, v, tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestExtractUnmanagedIPs_MalformedInput(t *testing.T) {
+	managed := []netip.Prefix{netip.MustParsePrefix("2001:db8::/32")}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{name: "multiple commas", input: ",,,", expected: nil},
+		{name: "garbage entry preserved", input: "not-an-ip", expected: []string{"not-an-ip"}},
+		{name: "garbage mixed with valid IPs", input: "192.168.1.1,garbage,2001:db8::1", expected: []string{"192.168.1.1", "garbage"}},
+		{name: "CIDR notation preserved as-is", input: "10.0.0.0/24,2001:db8::1", expected: []string{"10.0.0.0/24"}},
+		{name: "IP with port preserved", input: "192.168.1.1:8080", expected: []string{"192.168.1.1:8080"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractUnmanagedIPs(tt.input, managed)
+			if len(result) != len(tt.expected) {
+				t.Fatalf("got %d items %v, want %d items %v", len(result), result, len(tt.expected), tt.expected)
+			}
+			for i, v := range result {
+				if v != tt.expected[i] {
+					t.Errorf("[%d] = %q, want %q", i, v, tt.expected[i])
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- add `dynamic-prefix.io/service-suffix` so HA-managed Services can keep a fixed IPv6 host portion across prefix changes
- calculate managed current and historical IPv6 targets directly from the configured suffix
- include focused tests for suffix-based address calculation and annotation handling

## Testing
- ran focused ServiceSync controller tests

## Note
- this branch currently includes the unmanaged dual-stack preservation groundwork from #9 because the suffix feature builds on that behavior

Closes #3