### PR TITLE
chore: bump go to 1.26

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.24",
+  "image": "golang:1.26",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24 AS builder
+FROM golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ CONTAINER_TOOL ?= docker
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
+# Define space for path escaping
+space := $(subst ,, )
+
 .PHONY: all
 all: build
 
@@ -185,7 +188,9 @@ undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.
 
 ## Location to install dependencies to
 LOCALBIN ?= $(shell pwd)/bin
-$(LOCALBIN):
+# Escape spaces in LOCALBIN
+LOCALBIN_ESC = $(subst $(space),\ ,$(LOCALBIN))
+$(LOCALBIN_ESC):
 	mkdir -p "$(LOCALBIN)"
 
 ## Tool Binaries
@@ -195,6 +200,12 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
+
+# Escape spaces in tool paths
+KUSTOMIZE_ESC = $(subst $(space),\ ,$(KUSTOMIZE))
+CONTROLLER_GEN_ESC = $(subst $(space),\ ,$(CONTROLLER_GEN))
+ENVTEST_ESC = $(subst $(space),\ ,$(ENVTEST))
+GOLANGCI_LINT_ESC = $(subst $(space),\ ,$(GOLANGCI_LINT))
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.7.1
@@ -212,13 +223,13 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
 
 GOLANGCI_LINT_VERSION ?= v2.5.0
 .PHONY: kustomize
-kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
-$(KUSTOMIZE): $(LOCALBIN)
+kustomize: $(KUSTOMIZE_ESC) ## Download kustomize locally if necessary.
+$(KUSTOMIZE_ESC): $(LOCALBIN_ESC)
 	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v5,$(KUSTOMIZE_VERSION))
 
 .PHONY: controller-gen
-controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
-$(CONTROLLER_GEN): $(LOCALBIN)
+controller-gen: $(CONTROLLER_GEN_ESC) ## Download controller-gen locally if necessary.
+$(CONTROLLER_GEN_ESC): $(LOCALBIN_ESC)
 	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen,$(CONTROLLER_TOOLS_VERSION))
 
 .PHONY: setup-envtest
@@ -230,13 +241,13 @@ setup-envtest: envtest ## Download the binaries required for ENVTEST in the loca
 	}
 
 .PHONY: envtest
-envtest: $(ENVTEST) ## Download setup-envtest locally if necessary.
-$(ENVTEST): $(LOCALBIN)
+envtest: $(ENVTEST_ESC) ## Download setup-envtest locally if necessary.
+$(ENVTEST_ESC): $(LOCALBIN_ESC)
 	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest,$(ENVTEST_VERSION))
 
 .PHONY: golangci-lint
-golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
-$(GOLANGCI_LINT): $(LOCALBIN)
+golangci-lint: $(GOLANGCI_LINT_ESC) ## Download golangci-lint locally if necessary.
+$(GOLANGCI_LINT_ESC): $(LOCALBIN_ESC)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,6 @@ CONTAINER_TOOL ?= docker
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
-# Define space for path escaping
-space := $(subst ,, )
-
 .PHONY: all
 all: build
 
@@ -188,9 +185,7 @@ undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.
 
 ## Location to install dependencies to
 LOCALBIN ?= $(shell pwd)/bin
-# Escape spaces in LOCALBIN
-LOCALBIN_ESC = $(subst $(space),\ ,$(LOCALBIN))
-$(LOCALBIN_ESC):
+$(LOCALBIN):
 	mkdir -p "$(LOCALBIN)"
 
 ## Tool Binaries
@@ -200,12 +195,6 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
-
-# Escape spaces in tool paths
-KUSTOMIZE_ESC = $(subst $(space),\ ,$(KUSTOMIZE))
-CONTROLLER_GEN_ESC = $(subst $(space),\ ,$(CONTROLLER_GEN))
-ENVTEST_ESC = $(subst $(space),\ ,$(ENVTEST))
-GOLANGCI_LINT_ESC = $(subst $(space),\ ,$(GOLANGCI_LINT))
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.7.1
@@ -223,13 +212,13 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
 
 GOLANGCI_LINT_VERSION ?= v2.5.0
 .PHONY: kustomize
-kustomize: $(KUSTOMIZE_ESC) ## Download kustomize locally if necessary.
-$(KUSTOMIZE_ESC): $(LOCALBIN_ESC)
+kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
+$(KUSTOMIZE): $(LOCALBIN)
 	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v5,$(KUSTOMIZE_VERSION))
 
 .PHONY: controller-gen
-controller-gen: $(CONTROLLER_GEN_ESC) ## Download controller-gen locally if necessary.
-$(CONTROLLER_GEN_ESC): $(LOCALBIN_ESC)
+controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
+$(CONTROLLER_GEN): $(LOCALBIN)
 	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen,$(CONTROLLER_TOOLS_VERSION))
 
 .PHONY: setup-envtest
@@ -241,13 +230,13 @@ setup-envtest: envtest ## Download the binaries required for ENVTEST in the loca
 	}
 
 .PHONY: envtest
-envtest: $(ENVTEST_ESC) ## Download setup-envtest locally if necessary.
-$(ENVTEST_ESC): $(LOCALBIN_ESC)
+envtest: $(ENVTEST) ## Download setup-envtest locally if necessary.
+$(ENVTEST): $(LOCALBIN)
 	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest,$(ENVTEST_VERSION))
 
 .PHONY: golangci-lint
-golangci-lint: $(GOLANGCI_LINT_ESC) ## Download golangci-lint locally if necessary.
-$(GOLANGCI_LINT_ESC): $(LOCALBIN_ESC)
+golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
+$(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jr42/dynamic-prefix-operator
 
-go 1.24.6
+go 1.26.0
 
 require (
 	github.com/insomniacslk/dhcp v0.0.0-20251020182700-175e84fbb167


### PR DESCRIPTION
## Summary
- bump the Go toolchain in `go.mod`
- update the Docker build image to Go 1.26
- update the devcontainer image to Go 1.26