### PR TITLE
ci: improve release automation

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -13,7 +13,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:
@@ -31,6 +30,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Convert repository name to lowercase
+        id: image_name
+        uses: ASzc/change-string-case-action@v6
+        with:
+          string: ${{ github.repository }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -56,16 +61,16 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ steps.image_name.outputs.lowercase }}
           # Suffix tags with architecture for per-arch pulls
           flavor: |
             suffix=-${{ steps.platform.outputs.short }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha,prefix=
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
 
       - name: Build and push Docker image
         id: build
@@ -78,6 +83,7 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
           platforms: ${{ matrix.platform }}
+          provenance: false
 
       - name: Export digest
         if: github.event_name != 'pull_request'
@@ -105,6 +111,12 @@ jobs:
       packages: write
 
     steps:
+      - name: Convert repository name to lowercase
+        id: image_name
+        uses: ASzc/change-string-case-action@v6
+        with:
+          string: ${{ github.repository }}
+
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
@@ -126,16 +138,15 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ steps.image_name.outputs.lowercase }}
           tags: |
             type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha,prefix=
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
 
       - name: Create and push manifest
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+            $(printf '${{ env.REGISTRY }}/${{ steps.image_name.outputs.lowercase }}@sha256:%s ' *)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,31 +29,51 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v4
         with:
-          version: v3.14.0
+          version: v4.1.1
 
-      - name: Get version from tag
-        id: version
-        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+      - name: Set up Kustomize
+        uses: imranismail/setup-kustomize@v2
+        with:
+          kustomize-version: "5.8.1"
 
-      - name: Update Chart version
+      - name: Determine Prerelease Status
+        id: prerelease
         run: |
-          sed -i "s/^version:.*/version: ${{ steps.version.outputs.version }}/" charts/dynamic-prefix-operator/Chart.yaml
-          sed -i "s/^appVersion:.*/appVersion: \"${{ steps.version.outputs.version }}\"/" charts/dynamic-prefix-operator/Chart.yaml
-          # Update image tag to use the release version
-          sed -i "s/tag:.*/tag: \"v${{ steps.version.outputs.version }}\"/" charts/dynamic-prefix-operator/values.yaml
+          if [[ "${{ github.ref_name }}" == *"-"* ]]; then
+            echo "is_prerelease=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_prerelease=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Render Chart.yaml from Template
+        run: |
+          TEMPLATE_FILE="charts/dynamic-prefix-operator/Chart.template.yaml"
+          CHART_FILE="charts/dynamic-prefix-operator/Chart.yaml"
+          VALUES_FILE="charts/dynamic-prefix-operator/values.yaml"
+
+          VERSION="${{ github.ref_name }}"
+          IS_PRE="${{ steps.prerelease.outputs.is_prerelease }}"
+
+          sed -e "s/{{IS_PRERELEASE}}/$IS_PRE/g" \
+              -e "s/^version: .*/version: $VERSION/" \
+              -e "s/^appVersion: .*/appVersion: \"$VERSION\"/" \
+              $TEMPLATE_FILE > $CHART_FILE
+
+          sed -i "s/tag:.*/tag: \"$VERSION\"/" $VALUES_FILE
+
+      - name: Convert repository to lowercase
+        id: repository
+        uses: ASzc/change-string-case-action@v6
+        with:
+          string: ${{ github.repository }}
 
       - name: Generate install.yaml
         run: |
-          # Install kustomize
-          go install sigs.k8s.io/kustomize/kustomize/v5@latest
-
-          # Update image in kustomize
           cd config/manager
-          $(go env GOPATH)/bin/kustomize edit set image controller=${{ env.REGISTRY }}/${{ github.repository }}:v${{ steps.version.outputs.version }}
+          kustomize edit set image controller=${{ env.REGISTRY }}/${{ steps.repository.outputs.lowercase }}:${{ github.ref_name }}
           cd ../..
 
-          # Build the full manifest
-          $(go env GOPATH)/bin/kustomize build config/default > install.yaml
+          kustomize build config/default > install.yaml
 
       - name: Package Helm chart
         run: |
@@ -66,9 +86,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Convert repository owner to lowercase
+        id: repository_owner
+        uses: ASzc/change-string-case-action@v6
+        with:
+          string: ${{ github.repository_owner }}
+
       - name: Push Helm chart to OCI registry
         run: |
-          helm push dynamic-prefix-operator-${{ steps.version.outputs.version }}.tgz oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/dynamic-prefix-operator/helm
+          helm push dynamic-prefix-operator-${{ github.ref_name }}.tgz oci://${{ env.REGISTRY }}/${{ steps.repository_owner.outputs.lowercase }}/dynamic-prefix-operator/helm
 
       - name: Generate release notes
         id: notes
@@ -80,14 +106,14 @@ jobs:
 
           ```bash
           helm install dynamic-prefix-operator \
-            oci://ghcr.io/${{ github.repository_owner }}/dynamic-prefix-operator/helm/dynamic-prefix-operator \
-            --version ${{ steps.version.outputs.version }}
+            oci://ghcr.io/${{ steps.repository_owner.outputs.lowercase }}/dynamic-prefix-operator/helm/dynamic-prefix-operator \
+            --version ${{ github.ref_name }}
           ```
 
           ### Using kubectl
 
           ```bash
-          kubectl apply -f https://github.com/${{ github.repository }}/releases/download/v${{ steps.version.outputs.version }}/install.yaml
+          kubectl apply -f https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/install.yaml
           ```
 
           ## Docker Images
@@ -95,19 +121,24 @@ jobs:
           Multi-arch images (amd64, arm64) are available at:
 
           ```
-          ghcr.io/${{ github.repository }}:v${{ steps.version.outputs.version }}
+          ghcr.io/${{ steps.repository.outputs.lowercase }}:${{ github.ref_name }}
           ```
 
           ## What's Changed
 
-          See the [commit history](https://github.com/${{ github.repository }}/commits/v${{ steps.version.outputs.version }}) for details.
+          See the [commit history](https://github.com/${{ github.repository }}/commits/${{ github.ref_name }}) for details.
           EOF
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          body_path: release-notes.md
-          files: |
-            install.yaml
-            dynamic-prefix-operator-${{ steps.version.outputs.version }}.tgz
-          fail_on_unmatched_files: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${{ github.ref_name }}"
+          if gh release view "$tag" > /dev/null 2>&1; then
+            gh release upload "$tag" install.yaml dynamic-prefix-operator-${{ github.ref_name }}.tgz --clobber
+          else
+            gh release create "$tag" \
+              --target "${{ github.sha }}" \
+              --generate-notes \
+              install.yaml dynamic-prefix-operator-${{ github.ref_name }}.tgz
+          fi

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ CONTAINER_TOOL ?= docker
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
+# Define space for path escaping
+space := $(subst ,, )
+
 .PHONY: all
 all: build
 
@@ -185,7 +188,9 @@ undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.
 
 ## Location to install dependencies to
 LOCALBIN ?= $(shell pwd)/bin
-$(LOCALBIN):
+# Escape spaces in LOCALBIN
+LOCALBIN_ESC = $(subst $(space),\ ,$(LOCALBIN))
+$(LOCALBIN_ESC):
 	mkdir -p "$(LOCALBIN)"
 
 ## Tool Binaries
@@ -195,6 +200,12 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
+
+# Escape spaces in tool paths
+KUSTOMIZE_ESC = $(subst $(space),\ ,$(KUSTOMIZE))
+CONTROLLER_GEN_ESC = $(subst $(space),\ ,$(CONTROLLER_GEN))
+ENVTEST_ESC = $(subst $(space),\ ,$(ENVTEST))
+GOLANGCI_LINT_ESC = $(subst $(space),\ ,$(GOLANGCI_LINT))
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.7.1
@@ -212,13 +223,13 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
 
 GOLANGCI_LINT_VERSION ?= v2.5.0
 .PHONY: kustomize
-kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
-$(KUSTOMIZE): $(LOCALBIN)
+kustomize: $(KUSTOMIZE_ESC) ## Download kustomize locally if necessary.
+$(KUSTOMIZE_ESC): $(LOCALBIN_ESC)
 	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v5,$(KUSTOMIZE_VERSION))
 
 .PHONY: controller-gen
-controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
-$(CONTROLLER_GEN): $(LOCALBIN)
+controller-gen: $(CONTROLLER_GEN_ESC) ## Download controller-gen locally if necessary.
+$(CONTROLLER_GEN_ESC): $(LOCALBIN_ESC)
 	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen,$(CONTROLLER_TOOLS_VERSION))
 
 .PHONY: setup-envtest
@@ -230,13 +241,13 @@ setup-envtest: envtest ## Download the binaries required for ENVTEST in the loca
 	}
 
 .PHONY: envtest
-envtest: $(ENVTEST) ## Download setup-envtest locally if necessary.
-$(ENVTEST): $(LOCALBIN)
+envtest: $(ENVTEST_ESC) ## Download setup-envtest locally if necessary.
+$(ENVTEST_ESC): $(LOCALBIN_ESC)
 	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest,$(ENVTEST_VERSION))
 
 .PHONY: golangci-lint
-golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
-$(GOLANGCI_LINT): $(LOCALBIN)
+golangci-lint: $(GOLANGCI_LINT_ESC) ## Download golangci-lint locally if necessary.
+$(GOLANGCI_LINT_ESC): $(LOCALBIN_ESC)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist

--- a/charts/dynamic-prefix-operator/.helmignore
+++ b/charts/dynamic-prefix-operator/.helmignore
@@ -21,3 +21,27 @@
 .idea/
 *.tmproj
 .vscode/
+# Template files
+Chart.template.yaml# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/dynamic-prefix-operator/Chart.template.yaml
+++ b/charts/dynamic-prefix-operator/Chart.template.yaml
@@ -1,0 +1,33 @@
+apiVersion: v2
+
+name: dynamic-prefix-operator
+description: |
+  A Kubernetes operator for managing dynamic IPv6 prefix delegation.
+  Automatically updates Cilium LoadBalancerIPPools, CIDRGroups, and other
+  resources when your ISP-delegated IPv6 prefix changes.
+
+keywords:
+  - kubernetes
+  - operator
+  - ipv6
+  - dhcpv6
+  - prefix-delegation
+  - cilium
+  - networking
+
+home: https://github.com/jr42/dynamic-prefix-operator
+sources:
+  - https://github.com/jr42/dynamic-prefix-operator
+
+maintainers:
+  - name: jr42
+    url: https://github.com/jr42
+
+annotations:
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/category: networking
+  artifacthub.io/prerelease: "{{IS_PRERELEASE}}"
+
+# The version and appVersion fields are set automatically by the release tool
+version: v0.0.0
+appVersion: v0.0.0


### PR DESCRIPTION
## Summary
- update golangci-lint to v2.10.1
- improve Docker publishing with lowercase image names and stable tag handling
- switch release automation to templated Helm chart rendering and `gh`-based uploads
- add Helm packaging ignore rules for the chart template