### PR TITLE
fix: share RA receivers by interface

### DIFF
--- a/internal/prefix/factory.go
+++ b/internal/prefix/factory.go
@@ -18,6 +18,7 @@ package prefix
 
 import (
 	"fmt"
+	"sync"
 
 	dynamicprefixiov1alpha1 "github.com/jr42/dynamic-prefix-operator/api/v1alpha1"
 )
@@ -29,11 +30,19 @@ type ReceiverFactory interface {
 }
 
 // DefaultReceiverFactory is the default implementation of ReceiverFactory.
-type DefaultReceiverFactory struct{}
+type DefaultReceiverFactory struct {
+	mu            sync.Mutex
+	raReceivers   *sharedRAReceiverPool
+	newRAReceiver func(iface string) Receiver
+}
 
 // NewReceiverFactory creates a new DefaultReceiverFactory.
 func NewReceiverFactory() *DefaultReceiverFactory {
-	return &DefaultReceiverFactory{}
+	return &DefaultReceiverFactory{
+		newRAReceiver: func(iface string) Receiver {
+			return NewRAReceiver(iface)
+		},
+	}
 }
 
 // CreateReceiver creates a Receiver based on the AcquisitionSpec.
@@ -75,12 +84,12 @@ func (f *DefaultReceiverFactory) createDHCPv6PDReceiver(spec *dynamicprefixiov1a
 }
 
 // createRAReceiver creates a Router Advertisement receiver from the spec.
-func (f *DefaultReceiverFactory) createRAReceiver(spec *dynamicprefixiov1alpha1.RouterAdvertisementSpec) (*RAReceiver, error) {
+func (f *DefaultReceiverFactory) createRAReceiver(spec *dynamicprefixiov1alpha1.RouterAdvertisementSpec) (Receiver, error) {
 	if spec.Interface == "" {
 		return nil, fmt.Errorf("router advertisement interface is required")
 	}
 
-	return NewRAReceiver(spec.Interface), nil
+	return f.sharedRAPool().subscribe(spec.Interface), nil
 }
 
 // createCompositeReceiver creates a composite receiver with DHCPv6-PD as primary and RA as fallback.
@@ -96,4 +105,20 @@ func (f *DefaultReceiverFactory) createCompositeReceiver(spec dynamicprefixiov1a
 	}
 
 	return NewCompositeReceiver(primary, fallback), nil
+}
+
+func (f *DefaultReceiverFactory) sharedRAPool() *sharedRAReceiverPool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.newRAReceiver == nil {
+		f.newRAReceiver = func(iface string) Receiver {
+			return NewRAReceiver(iface)
+		}
+	}
+	if f.raReceivers == nil {
+		f.raReceivers = newSharedRAReceiverPool(f.newRAReceiver)
+	}
+
+	return f.raReceivers
 }

--- a/internal/prefix/shared_ra_receiver.go
+++ b/internal/prefix/shared_ra_receiver.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2026 jr42.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prefix
+
+import (
+	"context"
+	"sync"
+)
+
+type newReceiverFunc func(iface string) Receiver
+
+type sharedRAReceiverPool struct {
+	mu          sync.Mutex
+	entries     map[string]*sharedRAReceiverEntry
+	newReceiver newReceiverFunc
+}
+
+func newSharedRAReceiverPool(newReceiver newReceiverFunc) *sharedRAReceiverPool {
+	return &sharedRAReceiverPool{
+		entries:     make(map[string]*sharedRAReceiverEntry),
+		newReceiver: newReceiver,
+	}
+}
+
+func (p *sharedRAReceiverPool) subscribe(iface string) Receiver {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	entry := p.entries[iface]
+	if entry == nil {
+		entry = &sharedRAReceiverEntry{
+			iface:       iface,
+			receiver:    p.newReceiver(iface),
+			subscribers: make(map[*sharedRAReceiverSubscription]struct{}),
+		}
+		p.entries[iface] = entry
+	}
+
+	return &sharedRAReceiverSubscription{
+		pool:   p,
+		entry:  entry,
+		iface:  iface,
+		events: make(chan Event, 10),
+	}
+}
+
+func (p *sharedRAReceiverPool) unsubscribe(iface string, entry *sharedRAReceiverEntry, sub *sharedRAReceiverSubscription) error {
+	p.mu.Lock()
+	if p.entries[iface] != entry {
+		p.mu.Unlock()
+		return nil
+	}
+
+	shouldStop := entry.removeSubscriber(sub)
+	if shouldStop {
+		delete(p.entries, iface)
+	}
+	p.mu.Unlock()
+
+	if shouldStop {
+		return entry.stop()
+	}
+	return nil
+}
+
+type sharedRAReceiverEntry struct {
+	mu          sync.RWMutex
+	iface       string
+	receiver    Receiver
+	subscribers map[*sharedRAReceiverSubscription]struct{}
+	started     bool
+	ctx         context.Context
+	cancel      context.CancelFunc
+	stopCh      chan struct{}
+}
+
+func (e *sharedRAReceiverEntry) addSubscriber(ctx context.Context, sub *sharedRAReceiverSubscription) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if _, ok := e.subscribers[sub]; ok {
+		return nil
+	}
+
+	if !e.started {
+		e.ctx, e.cancel = context.WithCancel(ctx)
+		e.stopCh = make(chan struct{})
+		if err := e.receiver.Start(e.ctx); err != nil {
+			e.cancel()
+			e.ctx = nil
+			e.cancel = nil
+			e.stopCh = nil
+			return err
+		}
+		e.started = true
+		go e.fanOut(e.stopCh)
+	}
+
+	e.subscribers[sub] = struct{}{}
+	return nil
+}
+
+func (e *sharedRAReceiverEntry) removeSubscriber(sub *sharedRAReceiverSubscription) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	delete(e.subscribers, sub)
+	return len(e.subscribers) == 0 && e.started
+}
+
+func (e *sharedRAReceiverEntry) stop() error {
+	e.mu.Lock()
+	if !e.started {
+		e.mu.Unlock()
+		return nil
+	}
+
+	stopCh := e.stopCh
+	cancel := e.cancel
+	e.started = false
+	e.ctx = nil
+	e.cancel = nil
+	e.stopCh = nil
+	e.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	if stopCh != nil {
+		close(stopCh)
+	}
+
+	return e.receiver.Stop()
+}
+
+func (e *sharedRAReceiverEntry) fanOut(stopCh <-chan struct{}) {
+	events := e.receiver.Events()
+	for {
+		select {
+		case <-stopCh:
+			return
+		case event, ok := <-events:
+			if !ok {
+				return
+			}
+			e.broadcast(event)
+		}
+	}
+}
+
+func (e *sharedRAReceiverEntry) broadcast(event Event) {
+	e.mu.RLock()
+	subscribers := make([]*sharedRAReceiverSubscription, 0, len(e.subscribers))
+	for sub := range e.subscribers {
+		subscribers = append(subscribers, sub)
+	}
+	e.mu.RUnlock()
+
+	for _, sub := range subscribers {
+		sub.send(event)
+	}
+}
+
+type sharedRAReceiverSubscription struct {
+	mu      sync.Mutex
+	pool    *sharedRAReceiverPool
+	entry   *sharedRAReceiverEntry
+	iface   string
+	events  chan Event
+	started bool
+}
+
+func (s *sharedRAReceiverSubscription) Start(ctx context.Context) error {
+	s.mu.Lock()
+	if s.started {
+		s.mu.Unlock()
+		return nil
+	}
+	s.started = true
+	s.mu.Unlock()
+
+	if err := s.entry.addSubscriber(ctx, s); err != nil {
+		s.mu.Lock()
+		s.started = false
+		s.mu.Unlock()
+		return err
+	}
+	return nil
+}
+
+func (s *sharedRAReceiverSubscription) Stop() error {
+	s.mu.Lock()
+	if !s.started {
+		s.mu.Unlock()
+		return nil
+	}
+	s.started = false
+	s.mu.Unlock()
+
+	return s.pool.unsubscribe(s.iface, s.entry, s)
+}
+
+func (s *sharedRAReceiverSubscription) Events() <-chan Event {
+	return s.events
+}
+
+func (s *sharedRAReceiverSubscription) CurrentPrefix() *Prefix {
+	return s.entry.receiver.CurrentPrefix()
+}
+
+func (s *sharedRAReceiverSubscription) Source() Source {
+	return s.entry.receiver.Source()
+}
+
+func (s *sharedRAReceiverSubscription) send(event Event) {
+	select {
+	case s.events <- event:
+	default:
+		// Slow subscribers should not block delivery to other DynamicPrefix resources.
+	}
+}

--- a/internal/prefix/shared_ra_receiver_test.go
+++ b/internal/prefix/shared_ra_receiver_test.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2026 jr42.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prefix
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+	"time"
+
+	dynamicprefixiov1alpha1 "github.com/jr42/dynamic-prefix-operator/api/v1alpha1"
+)
+
+func TestDefaultReceiverFactory_SharesRAReceiverByInterface(t *testing.T) {
+	ctx := context.Background()
+	underlying := newInstrumentedReceiver(SourceRouterAdvertisement)
+	created := 0
+
+	factory := &DefaultReceiverFactory{
+		newRAReceiver: func(iface string) Receiver {
+			created++
+			return underlying
+		},
+	}
+
+	spec := dynamicprefixiov1alpha1.AcquisitionSpec{
+		RouterAdvertisement: &dynamicprefixiov1alpha1.RouterAdvertisementSpec{
+			Interface: "eth0",
+			Enabled:   true,
+		},
+	}
+
+	receiverA, err := factory.CreateReceiver(spec)
+	if err != nil {
+		t.Fatalf("CreateReceiver() A error = %v", err)
+	}
+	receiverB, err := factory.CreateReceiver(spec)
+	if err != nil {
+		t.Fatalf("CreateReceiver() B error = %v", err)
+	}
+
+	if created != 1 {
+		t.Fatalf("created %d underlying RA receivers, want 1", created)
+	}
+	if receiverA == receiverB {
+		t.Fatal("expected distinct subscriber receivers")
+	}
+
+	if err := receiverA.Start(ctx); err != nil {
+		t.Fatalf("receiverA.Start() error = %v", err)
+	}
+	if err := receiverB.Start(ctx); err != nil {
+		t.Fatalf("receiverB.Start() error = %v", err)
+	}
+	if underlying.startCount != 1 {
+		t.Fatalf("underlying start count = %d, want 1", underlying.startCount)
+	}
+
+	prefix := &Prefix{
+		Network:           netip.MustParsePrefix("2001:db8::/48"),
+		ValidLifetime:     time.Hour,
+		PreferredLifetime: time.Hour,
+		Source:            SourceRouterAdvertisement,
+		ReceivedAt:        time.Now(),
+	}
+	underlying.setPrefix(prefix)
+	underlying.emit(Event{Type: EventTypeAcquired, Prefix: prefix})
+
+	expectEvent(t, receiverA.Events(), EventTypeAcquired, prefix.Network)
+	expectEvent(t, receiverB.Events(), EventTypeAcquired, prefix.Network)
+
+	if receiverA.CurrentPrefix().Network != prefix.Network {
+		t.Fatalf("receiverA.CurrentPrefix() = %v, want %v", receiverA.CurrentPrefix().Network, prefix.Network)
+	}
+	if receiverB.CurrentPrefix().Network != prefix.Network {
+		t.Fatalf("receiverB.CurrentPrefix() = %v, want %v", receiverB.CurrentPrefix().Network, prefix.Network)
+	}
+
+	if err := receiverA.Stop(); err != nil {
+		t.Fatalf("receiverA.Stop() error = %v", err)
+	}
+	if underlying.stopCount != 0 {
+		t.Fatalf("underlying stopped while a subscriber remained: %d", underlying.stopCount)
+	}
+
+	if err := receiverB.Stop(); err != nil {
+		t.Fatalf("receiverB.Stop() error = %v", err)
+	}
+	if underlying.stopCount != 1 {
+		t.Fatalf("underlying stop count = %d, want 1", underlying.stopCount)
+	}
+}
+
+func TestDefaultReceiverFactory_CreatesSeparateRAReceiversForDifferentInterfaces(t *testing.T) {
+	createdByInterface := map[string]int{}
+	factory := &DefaultReceiverFactory{
+		newRAReceiver: func(iface string) Receiver {
+			createdByInterface[iface]++
+			return newInstrumentedReceiver(SourceRouterAdvertisement)
+		},
+	}
+
+	for _, iface := range []string{"eth0", "eth1", "eth0"} {
+		_, err := factory.CreateReceiver(dynamicprefixiov1alpha1.AcquisitionSpec{
+			RouterAdvertisement: &dynamicprefixiov1alpha1.RouterAdvertisementSpec{
+				Interface: iface,
+				Enabled:   true,
+			},
+		})
+		if err != nil {
+			t.Fatalf("CreateReceiver(%s) error = %v", iface, err)
+		}
+	}
+
+	if createdByInterface["eth0"] != 1 {
+		t.Fatalf("eth0 created %d receivers, want 1", createdByInterface["eth0"])
+	}
+	if createdByInterface["eth1"] != 1 {
+		t.Fatalf("eth1 created %d receivers, want 1", createdByInterface["eth1"])
+	}
+}
+
+func expectEvent(t *testing.T, events <-chan Event, eventType EventType, network netip.Prefix) {
+	t.Helper()
+
+	select {
+	case event := <-events:
+		if event.Type != eventType {
+			t.Fatalf("event.Type = %s, want %s", event.Type, eventType)
+		}
+		if event.Prefix == nil || event.Prefix.Network != network {
+			t.Fatalf("event.Prefix = %v, want %v", event.Prefix, network)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for %s event", eventType)
+	}
+}
+
+type instrumentedReceiver struct {
+	source        Source
+	events        chan Event
+	currentPrefix *Prefix
+	startCount    int
+	stopCount     int
+	started       bool
+}
+
+func newInstrumentedReceiver(source Source) *instrumentedReceiver {
+	return &instrumentedReceiver{
+		source: source,
+		events: make(chan Event, 10),
+	}
+}
+
+func (r *instrumentedReceiver) Start(ctx context.Context) error {
+	r.startCount++
+	r.started = true
+	return nil
+}
+
+func (r *instrumentedReceiver) Stop() error {
+	r.stopCount++
+	r.started = false
+	return nil
+}
+
+func (r *instrumentedReceiver) Events() <-chan Event {
+	return r.events
+}
+
+func (r *instrumentedReceiver) CurrentPrefix() *Prefix {
+	return r.currentPrefix
+}
+
+func (r *instrumentedReceiver) Source() Source {
+	return r.source
+}
+
+func (r *instrumentedReceiver) setPrefix(prefix *Prefix) {
+	r.currentPrefix = prefix
+}
+
+func (r *instrumentedReceiver) emit(event Event) {
+	r.events <- event
+}


### PR DESCRIPTION
## Summary
- add a shared Router Advertisement receiver pool keyed by network interface
- return per-DynamicPrefix subscription receivers with independent event channels
- start one underlying RA listener per interface and stop it only after the last subscriber stops
- cover shared fan-out, ref-counted stop, and per-interface separation with tests

## Testing
- `go test ./internal/prefix -count=1`
- `go test ./... -count=1`
- `make lint`

Fixes #17
